### PR TITLE
Adds Qt5 support

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,0 +1,9 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#if QT_VERSION >= 0x050000
+	#include <QUrlQuery>
+	#define O2_USE_QURLQUERY 1
+#endif
+
+#endif // COMMON_H

--- a/o1.h
+++ b/o1.h
@@ -9,6 +9,7 @@
 #include <QNetworkAccessManager>
 #include <QUrl>
 #include <QNetworkReply>
+#include "common.h"
 
 class O2ReplyServer;
 class SimpleCrypt;

--- a/o1requestor.cpp
+++ b/o1requestor.cpp
@@ -53,12 +53,12 @@ QNetworkReply *O1Requestor::addTimer(QNetworkReply *reply) {
 QNetworkRequest O1Requestor::setup(const QNetworkRequest &req, const QList<O1RequestParameter> &signingParameters, QNetworkAccessManager::Operation operation) {
     // Collect OAuth parameters
     QList<O1RequestParameter> oauthParams;
-    oauthParams.append(O1RequestParameter("oauth_consumer_key", authenticator_->clientId().toAscii()));
+    oauthParams.append(O1RequestParameter("oauth_consumer_key", authenticator_->clientId().toUtf8()));
     oauthParams.append(O1RequestParameter("oauth_version", "1.0"));
-    oauthParams.append(O1RequestParameter("oauth_token", authenticator_->token().toAscii()));
+	oauthParams.append(O1RequestParameter("oauth_token", authenticator_->token().toUtf8()));
     oauthParams.append(O1RequestParameter("oauth_signature_method", "HMAC-SHA1"));
     oauthParams.append(O1RequestParameter("oauth_nonce", O1::nonce()));
-    oauthParams.append(O1RequestParameter("oauth_timestamp", QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toAscii()));
+    oauthParams.append(O1RequestParameter("oauth_timestamp", QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toUtf8()));
 
     // Add signature parameter
     QByteArray signature = authenticator_->sign(oauthParams, signingParameters, req.url(), operation, authenticator_->clientSecret(), authenticator_->tokenSecret());

--- a/o2.cpp
+++ b/o2.cpp
@@ -132,7 +132,13 @@ void O2::link() {
 
     // Show authentication URL with a web browser
     QUrl url(requestUrl_);
+#if !O2_USE_QURLQUERY
     url.setQueryItems(parameters);
+#else
+	QUrlQuery query(url);
+	query.setQueryItems(parameters);
+	url.setQuery(query);
+#endif
     trace() << " Emit openBrowser" << url.toString();
     emit openBrowser(url);
 }

--- a/o2.h
+++ b/o2.h
@@ -10,6 +10,7 @@
 #include <QNetworkReply>
 #include <QList>
 #include <QPair>
+#include "common.h"
 
 #include "o2reply.h"
 

--- a/o2.pri
+++ b/o2.pri
@@ -26,3 +26,4 @@ HEADERS += \
     $$PWD/o2requestor.h \
     $$PWD/simplecrypt.h \
     $$PWD/o2skydrive.h \
+    $$PWD/o2/common.h

--- a/o2facebook.cpp
+++ b/o2facebook.cpp
@@ -33,11 +33,21 @@ void O2Facebook::onVerificationReceived(const QMap<QString, QString> response) {
 
     // Exchange access code for access/refresh tokens
     QUrl url(tokenUrl_);
+#if !O2_USE_QURLQUERY
     url.addQueryItem("client_id", clientId_);
     url.addQueryItem("client_secret", clientSecret_);
     url.addQueryItem("scope", scope_);
     url.addQueryItem("code", code());
     url.addQueryItem("redirect_uri", redirectUri_);
+#else
+	QUrlQuery query(url);
+	query.addQueryItem("client_id", clientId_);
+    query.addQueryItem("client_secret", clientSecret_);
+    query.addQueryItem("scope", scope_);
+    query.addQueryItem("code", code());
+    query.addQueryItem("redirect_uri", redirectUri_);
+	url.setQuery(query);
+#endif
 
     QNetworkRequest tokenRequest(url);
     QNetworkReply *tokenReply = manager_->get(tokenRequest);

--- a/o2replyserver.cpp
+++ b/o2replyserver.cpp
@@ -51,7 +51,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
     splitGetLine.remove("\r\n");
     splitGetLine.prepend("http://localhost");
     QUrl getTokenUrl(splitGetLine);
-    QList< QPair<QString, QString> > tokens = getTokenUrl.queryItems();
+    QList< QPair<QString, QString> > tokens = QUrlQuery(getTokenUrl).queryItems();
     QMultiMap<QString, QString> queryParams;
     QPair<QString, QString> tokenPair;
     foreach (tokenPair, tokens) {

--- a/o2replyserver.h
+++ b/o2replyserver.h
@@ -5,6 +5,7 @@
 #include <QMap>
 #include <QByteArray>
 #include <QString>
+#include "common.h"
 
 /// HTTP server to process authentication response.
 class O2ReplyServer: public QTcpServer {

--- a/o2requestor.cpp
+++ b/o2requestor.cpp
@@ -127,7 +127,13 @@ int O2Requestor::setup(const QNetworkRequest &req, QNetworkAccessManager::Operat
     operation_ = operation;
     id_ = currentId++;
     url_ = url = req.url();
-    url.addQueryItem("access_token", authenticator_->token());
+#if !O2_USE_QURLQUERY
+	url.addQueryItem("access_token", authenticator_->token());
+#else
+	QUrlQuery query(url);
+    query.addQueryItem("access_token", authenticator_->token());
+	url.setQuery(query);
+#endif
     request_.setUrl(url);
     status_ = Requesting;
     error_ = QNetworkReply::NoError;
@@ -157,7 +163,13 @@ void O2Requestor::retry() {
     reply_->disconnect(this);
     reply_->deleteLater();
     QUrl url = url_;
+#if !O2_USE_QURLQUERY
     url.addQueryItem("access_token", authenticator_->token());
+#else
+	QUrlQuery query(url);
+	query.addQueryItem("access_token", authenticator_->token());
+	url.setQuery(query);
+#endif
     request_.setUrl(url);
     status_ = ReRequesting;
     switch (operation_) {

--- a/o2skydrive.cpp
+++ b/o2skydrive.cpp
@@ -34,7 +34,13 @@ void O2Skydrive::link() {
 
     // Show authentication URL with a web browser
     QUrl url(requestUrl_);
+#if !O2_USE_QURLQUERY
     url.setQueryItems(parameters);
+#else
+	QUrlQuery query(url);
+	query.setQueryItems(parameters);
+	url.setQuery(query);
+#endif
     emit openBrowser(url);
 }
 
@@ -45,7 +51,7 @@ void O2Skydrive::redirected(const QUrl &url) {
 
     if (grantFlow_ == GrantFlowAuthorizationCode) {
         // Get access code
-        QString urlCode = url.queryItemValue("code");
+        QString urlCode = QUrlQuery(url).queryItemValue("code");
         if (urlCode.isEmpty()) {
             trace() << " Code not received";
             emit linkingFailed();

--- a/simplecrypt.cpp
+++ b/simplecrypt.cpp
@@ -26,6 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "simplecrypt.h"
 #include <QByteArray>
+#include <QDataStream>
 #include <QtDebug>
 #include <QtGlobal>
 #include <QDateTime>
@@ -139,20 +140,20 @@ QString SimpleCrypt::encryptToString(const QString& plaintext)
 {
     QByteArray plaintextArray = plaintext.toUtf8();
     QByteArray cypher = encryptToByteArray(plaintextArray);
-    QString cypherString = QString::fromAscii(cypher.toBase64());
+    QString cypherString = QString::fromUtf8(cypher.toBase64());
     return cypherString;
 }
 
 QString SimpleCrypt::encryptToString(QByteArray plaintext)
 {
     QByteArray cypher = encryptToByteArray(plaintext);
-    QString cypherString = QString::fromAscii(cypher.toBase64());
+    QString cypherString = QString::fromUtf8(cypher.toBase64());
     return cypherString;
 }
 
 QString SimpleCrypt::decryptToString(const QString &cyphertext)
 {
-    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toAscii());
+    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toUtf8());
     QByteArray plaintextArray = decryptToByteArray(cyphertextArray);
     QString plaintext = QString::fromUtf8(plaintextArray, plaintextArray.size());
 
@@ -169,7 +170,7 @@ QString SimpleCrypt::decryptToString(QByteArray cypher)
 
 QByteArray SimpleCrypt::decryptToByteArray(const QString& cyphertext)
 {
-    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toAscii());
+    QByteArray cyphertextArray = QByteArray::fromBase64(cyphertext.toUtf8());
     QByteArray ba = decryptToByteArray(cyphertextArray);
 
     return ba;


### PR DESCRIPTION
Qt5 moves all of QUrl's query string functions into a separate class (QUrlQuery).
With the way that class works, this means two more lines for each query operation (and an extra stack allocation) for seemingly no good reason.

I could do this in an (in my opinion) cleaner fashion with macros, but I recall a lot of people don't like function-like macros for things like this.
