### PR TITLE
Support for extra tokens in OAuth response

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,9 @@ You can also create it with your customized QSettings object. O2SettingsStore wi
 Once set, O2SettingsStore takes ownership of the QSettings object.
 
 **Note:** If you do not specify a storage object to use, O2 will create one by default (which QSettings based), and use it. In such a case, a default encryption key is used for encrypting the data.
+
+### Extra OAuth Tokens
+Some OAuth service providers provide additional information in the access token response. Eg: Twitter returns 2 additional tokens in it's access token response - *screen_name* and *user_id*.
+
+O2 provides all such tokens via the property - *extraTokens*. You can query this property after a successful OAuth exchange, i.e after the *linkingSucceeded()* signal has been emitted.
+

--- a/o1.cpp
+++ b/o1.cpp
@@ -11,6 +11,7 @@
 
 #include "o1.h"
 #include "o2replyserver.h"
+#include "o2globals.h"
 #include "o2settingsstore.h"
 
 #define trace() if (1) qDebug()
@@ -120,11 +121,11 @@ void O1::setAccessTokenUrl(const QUrl &value) {
     emit accessTokenUrlChanged();
 }
 
-StrStrMap O1::extraTokens() const {
+QVariantMap O1::extraTokens() const {
     return extraTokens_;
 }
 
-void O1::setExtraTokens(QMap<QString, QString> extraTokens) {
+void O1::setExtraTokens(QVariantMap extraTokens) {
     extraTokens_ = extraTokens;
 }
 
@@ -365,9 +366,13 @@ void O1::onTokenExchangeFinished() {
     if (response.contains(O2_OAUTH_TOKEN) && response.contains(O2_OAUTH_TOKEN_SECRET)) {
         setToken(response.take(O2_OAUTH_TOKEN));
         setTokenSecret(response.take(O2_OAUTH_TOKEN_SECRET));
+        // Set extra tokens if any
         if (!response.isEmpty()) {
-            // Set extra tokens if any
-            setExtraTokens(response);
+            QVariantMap extraTokens;
+            foreach (QString key, response.keys()) {
+               extraTokens.insert(key, response.value(key));
+            }
+            setExtraTokens(extraTokens);
         }
         emit linkedChanged();
         emit linkingSucceeded();

--- a/o1.h
+++ b/o1.h
@@ -11,7 +11,6 @@
 #include <QNetworkReply>
 
 #include "o2abstractstore.h"
-#include "o2globals.h"
 
 class O2ReplyServer;
 
@@ -42,8 +41,8 @@ public:
     QString tokenSecret();
 
     /// Extra tokens available after a successful OAuth exchange
-    Q_PROPERTY(StrStrMap extraTokens READ extraTokens)
-    StrStrMap extraTokens() const;
+    Q_PROPERTY(QMap extraTokens READ extraTokens)
+    QVariantMap extraTokens() const;
 
     /// Client application ID.
     /// O1 instances with the same (client ID, client secret) share the same "linked", "token" and "tokenSecret" properties.
@@ -174,7 +173,7 @@ protected:
     virtual void exchangeToken();
 
     /// Set extra tokens found in OAuth response
-    void setExtraTokens(QMap<QString, QString> extraTokens);
+    void setExtraTokens(QVariantMap extraTokens);
 
 protected:
     QString clientId_;
@@ -192,7 +191,7 @@ protected:
     O2ReplyServer *replyServer_;
     quint16 localPort_;
     O2AbstractStore *store_;
-    QMap<QString, QString> extraTokens_;
+    QVariantMap extraTokens_;
 };
 
 #endif // O1_H

--- a/o2.h
+++ b/o2.h
@@ -13,7 +13,6 @@
 
 #include "o2reply.h"
 #include "o2abstractstore.h"
-#include "o2globals.h"
 
 class O2ReplyServer;
 
@@ -35,8 +34,8 @@ public:
     bool linked();
 
     /// Extra tokens available after a successful OAuth exchange
-    Q_PROPERTY(StrStrMap extraTokens READ extraTokens)
-    StrStrMap extraTokens() const;
+    Q_PROPERTY(QMap extraTokens READ extraTokens)
+    QVariantMap extraTokens() const;
 
     /// Authentication token.
     Q_PROPERTY(QString token READ token WRITE setToken NOTIFY tokenChanged)
@@ -170,7 +169,7 @@ protected:
     void setExpires(int v);
 
     /// Set extra tokens found in OAuth response
-    void setExtraTokens(QMap<QString, QString> extraTokens);
+    void setExtraTokens(QVariantMap extraTokens);
 
 protected:
     QString clientId_;
@@ -187,7 +186,7 @@ protected:
     quint16 localPort_;
     GrantFlow grantFlow_;
     O2AbstractStore *store_;
-    QMap<QString, QString> extraTokens_;
+    QVariantMap extraTokens_;
 };
 
 #endif // O2_H

--- a/o2globals.h
+++ b/o2globals.h
@@ -1,12 +1,6 @@
 #ifndef O2GLOBALS_H
 #define O2GLOBALS_H
 
-#include <QMap>
-#include <QString>
-
-// typedef for use in property declarations
-typedef QMap<QString, QString> StrStrMap;
-
 // Common constants
 const char O2_ENCRYPTION_KEY[] = "12345678";
 const char O2_CALLBACK_URL[] = "http://127.0.0.1:%1/";


### PR DESCRIPTION
Added support for making extra tokens in OAuth response, available as a property.

Certain OAuth service providers, provide extra information in the form of additional tokens that are returned as part of a successful OAuth exchange.

These additional tokens are made available as a read-only property. The property's type is QMap<QString, QString>.
