### PR TITLE
Twitter Demo: Access tokens NOT comitted on exit

### DIFF
--- a/examples/twitterdemo/main.cpp
+++ b/examples/twitterdemo/main.cpp
@@ -27,6 +27,9 @@ class Helper : public QObject
 {
     Q_OBJECT
 
+public:
+    Helper() : QObject(), tweeter_(this), waitForMsg_(false), msg_(QString()) {}
+
 public slots:
 
     void processArgs() {
@@ -88,10 +91,7 @@ public slots:
         if (waitForMsg_) {
             postStatusUpdate(msg_);
         } else {
-            // Give some time for the data to be written. Ideally, QSettings
-            // should call sync() while being destroyed, but this doesn't
-            // seem to be working
-            QTimer::singleShot(2000, qApp, SLOT(quit()));
+            qApp->quit();
         }
     }
 
@@ -113,7 +113,8 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
-    QTimer::singleShot(0, new Helper(), SLOT(processArgs()));
+    Helper helper;
+    QTimer::singleShot(0, &helper, SLOT(processArgs()));
 
     return a.exec();
 }


### PR DESCRIPTION
Fixed bug which caused tokens to be NOT comitted on app exit.

Any un-comitted changes are 'synced' when a QSettings object is destroyed. This happens in it's d'tor.

The bug was caused because the Helper class was created on the heap w/o a parent. So on application exit, it's d'tor was not getting called. This in turn prevented the QSettings d'tor from being called and any un-comitted data in QSettings was discarded.

Fix is to create the Helper on the stack for proper cleanup.

Bonus Fix:

The waitForMsg_ variable was not "value initialized". This meant that it had garbage value stored in it. This meant that sometimes, depending on its value, the slot Helper::postStatusUpdate() would get called. Fix was to explicitly initialize the boolean variable.
