### PR TITLE
O2 bug fixes

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -132,7 +132,8 @@ void O2::setExtraTokens(QVariantMap extraTokens) {
 void O2::link() {
     trace() << "O2::link";
     if (linked()) {
-        trace() << " Linked already";
+        trace() << "Linked already";
+        emit linkingSucceeded();
         return;
     }
 

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -24,11 +24,16 @@ O2ReplyServer::~O2ReplyServer() {
 }
 
 void O2ReplyServer::onIncomingConnection() {
-    socket = nextPendingConnection();
+    QTcpSocket* socket = nextPendingConnection();
     connect(socket, SIGNAL(readyRead()), this, SLOT(onBytesReady()), Qt::UniqueConnection);
+    connect(socket, SIGNAL(disconnected()), socket, SLOT(deleteLater()));
 }
 
 void O2ReplyServer::onBytesReady() {
+    QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
+    if (!socket) {
+        return;
+    }
     QByteArray reply;
     QByteArray content;
     content.append("<HTML></HTML>");

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -21,9 +21,6 @@ public slots:
     void onIncomingConnection();
     void onBytesReady();
     QMap<QString, QString> parseQueryParams(QByteArray *data);
-
-public:
-    QTcpSocket *socket;
 };
 
 #endif // O2REPLYSERVER_H


### PR DESCRIPTION
Correct handling of multiple incoming connections in O2ReplyServer

O2ReplyServer:
- We are using a single variable to store the client socket
  pointer. In case we get multiple incoming connections, we end
  up overwriting the socket pointers. Subsequently when we get
  the readyRead() signal we don't have a way of getting the
  pointer.

Fix is to not store the client socket in a member variable.
The pointer in O2ReplyServer::onBytesReady() is got using the
sender() function. This way we can read data from the correct
socket even when handling multiple incoming connections.
- We were also leaking memory of the client socket as we were
  not deleting the object once we're done.

Fixed it by connecting the socket's disconnected() signal to
its deleteLater() slot.

O2:
- There was a bug where O2 was not emitting the linkingSucceeded()
  signal if the application was already linked.

Fixed this issue by emitting the signal.
