### PR TITLE
O1Requestor::get() didn't include query parameters

### DIFF
--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -441,7 +441,8 @@ QByteArray O1::nonce() {
         firstTime = false;
         qsrand(QTime::currentTime().msec());
     }
-    QString u = QString::number(QDateTime::currentDateTimeUtc().toTime_t());
-    u.append(QString::number(qrand()));
-    return u.toLatin1();
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1());
+    hash.addData(QString::number(qrand()).toLatin1());
+    return hash.result().toHex();
 }

--- a/src/o1requestor.cpp
+++ b/src/o1requestor.cpp
@@ -1,6 +1,7 @@
 #include <QDebug>
 #include <QTimer>
 #include <QDateTime>
+#include <QUrlQuery>
 #include <QNetworkReply>
 #include <QNetworkAccessManager>
 
@@ -33,6 +34,12 @@ O1Requestor::O1Requestor(QNetworkAccessManager *manager, O1 *authenticator, QObj
 
 QNetworkReply *O1Requestor::get(const QNetworkRequest &req, const QList<O1RequestParameter> &signingParameters) {
     QNetworkRequest request = setup(req, signingParameters, QNetworkAccessManager::GetOperation);
+    QUrlQuery query;
+    foreach (O1RequestParameter reqParam, signingParameters)
+      query.addQueryItem(reqParam.name, reqParam.value);
+    QUrl urlWithQuery = request.url();
+    urlWithQuery.setQuery(query);
+    request.setUrl(urlWithQuery);
     return addTimer(manager_->get(request));
 }
 


### PR DESCRIPTION
Commit 85be7f3: The `QList<O1RequestParameter>` argument given to `O1Requestor::get()` is correctly  incorporated into the OAuth signature, but `O1Requestor::get()` fails to produce the correct URL that contains the query parameters. Fixed this bug.

Optional commit db5a536: Updated `O1::nonce()` to produce a 32 byte hash to mimic the behavior of Twitter's OAuth Tool.
