### PR TITLE
Skip invalid response from Chrome

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -265,6 +265,8 @@ bool O2::linked() {
 void O2::onVerificationReceived(const QMap<QString, QString> response) {
     trace() << "O2::onVerificationReceived";
     trace() << "" << response;
+    if (response.isEmpty()) //Chrome (Firefox, IE and Safari do not) sends one of these
+        return; //after normal one, which ends up as an error "Missing required parameter(s): code" - so just skip it
 
     emit closeBrowser();
     if (response.contains("error")) {

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -499,6 +499,16 @@ void O2::setReplyContent(const QByteArray& value)
     replyServer_->setReplyContent(value);
 }
 
+QByteArray O2::replyContentType()
+{
+    return replyServer_->replyContentType();
+}
+
+void O2::setReplyContentType(const QByteArray& value)
+{
+    replyServer_->setReplyContentType(value);
+}
+
 bool O2::ignoreSslErrors()
 {
     return timedReplies_.ignoreSslErrors();

--- a/src/o2.h
+++ b/src/o2.h
@@ -109,6 +109,10 @@ public:
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
+    Q_PROPERTY(QByteArray replyContentType READ replyContentType WRITE setReplyContentType)
+    QByteArray replyContentType();
+    void setReplyContentType(const QByteArray &value);
+
     /// E.g. SurveyMonkey fails on Mac due to Ssl Error. Ignoring the error circumvents the problem
     Q_PROPERTY(bool ignoreSslErrors READ ignoreSslErrors WRITE setIgnoreSslErrors)
     bool ignoreSslErrors();

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -19,6 +19,7 @@
 O2ReplyServer::O2ReplyServer(QObject *parent): QTcpServer(parent) {
     connect(this, SIGNAL(newConnection()), this, SLOT(onIncomingConnection()));
         replyContent_ = "<HTML></HTML>";
+        replyContentType_ = "Content-Type: text/html; charset=\"utf-8\"";
 }
 
 O2ReplyServer::~O2ReplyServer() {
@@ -37,7 +38,7 @@ void O2ReplyServer::onBytesReady() {
     }
     QByteArray reply;
     reply.append("HTTP/1.0 200 OK \r\n");
-    reply.append("Content-Type: text/html; charset=\"utf-8\"\r\n");
+    reply.append(replyContentType_ + "\r\n");
     reply.append(QString("Content-Length: %1\r\n\r\n").arg(replyContent_.size()));
     reply.append(replyContent_);
     socket->write(reply);
@@ -85,4 +86,14 @@ QByteArray O2ReplyServer::replyContent()
 void O2ReplyServer::setReplyContent(const QByteArray& value)
 {
     replyContent_ = value;
+}
+
+QByteArray O2ReplyServer::replyContentType()
+{
+    return replyContentType_;
+}
+
+void O2ReplyServer::setReplyContentType(const QByteArray& value)
+{
+    replyContentType_ = value;
 }

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -19,6 +19,10 @@ public:
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
+        Q_PROPERTY(QByteArray replyContentType READ replyContentType WRITE setReplyContentType)
+    QByteArray replyContentType();
+    void setReplyContentType(const QByteArray &value);
+
 signals:
     void verificationReceived(QMap<QString, QString>);
 
@@ -28,7 +32,7 @@ public slots:
     QMap<QString, QString> parseQueryParams(QByteArray *data);
 
 protected:
-    QByteArray replyContent_;
+    QByteArray replyContent_, replyContentType_;
 };
 
 #endif // O2REPLYSERVER_H


### PR DESCRIPTION
Chrome sends an invalid response after o2auth, which leads to O2::onTokenReplyError being called and the bad alarm signals wrongfully emitted. This just skips it.