### PR TITLE
Use CMake options for GUI frontend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,25 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(o2)
 
+option(o2_WITH_QT5 "Use Qt5" ON)
+
+option(o2_WITH_TWITTER "Authenticate with Twitter" OFF)
+option(o2_WITH_DROPBOX "Authenticate with Dropbox" OFF)
+option(o2_WITH_GOOGLE "Authenticate with Google" OFF)
+option(o2_WITH_FACEBOOK "Authenticate with Facebook" OFF)
+option(o2_WITH_SKYDRIVE "Authenticate with SkyDrive" OFF)
+option(o2_WITH_FLICKR "Authenticate with Flickr" OFF)
+option(o2_WITH_HUBIC "Authenticate with Hubic" OFF)
+
+option(o2_WITH_OAUTH1 "Include OAuth1 authentication" OFF)
+if(o2_WITH_TWITTER OR o2_WITH_DROPBOX OR o2_WITH_FLICKR)
+  set(o2_WITH_OAUTH1 ON)
+endif()
+
+option(o2_BUILD_EXAMPLES "Build examples" OFF)
+
 add_subdirectory(src)
 
-if(BUILD_EXAMPLES)
+if(o2_BUILD_EXAMPLES)
   add_subdirectory(examples)
-endif(BUILD_EXAMPLES)
+endif(o2_BUILD_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.11)
 
-if(WITH_FACEBOOK)
+if(o2_WITH_FACEBOOK)
     add_subdirectory(facebookdemo)
-endif(WITH_FACEBOOK)
+endif(o2_WITH_FACEBOOK)
 
-if(WITH_TWITTER)
+if(o2_WITH_TWITTER)
     add_subdirectory(twitterdemo)
-endif(WITH_TWITTER)
+endif(o2_WITH_TWITTER)

--- a/examples/facebookdemo/CMakeLists.txt
+++ b/examples/facebookdemo/CMakeLists.txt
@@ -6,21 +6,21 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     # Qt5 packages find their own dependencies.
     find_package(Qt5Core    REQUIRED)
     find_package(Qt5Widgets REQUIRED)
     find_package(Qt5Script  REQUIRED)
     find_package(Qt5Network REQUIRED)
-else(WITH_QT5)
+else(o2_WITH_QT5)
     set(QT_USE_QTNETWORK true)
     set(QT_USE_QTSCRIPT true)
     find_package(Qt4 REQUIRED)
-endif(WITH_QT5)
+endif(o2_WITH_QT5)
 
-if (NOT WITH_QT5)
+if (NOT o2_WITH_QT5)
     include( ${QT_USE_FILE} )
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
 
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} "../../src" )
 
@@ -29,15 +29,15 @@ set(fb_SRCS
     fbdemo.cpp
 )
 
-if(NOT WITH_QT5)
+if(NOT o2_WITH_QT5)
     add_definitions(${QT4_DEFINITIONS})
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
 
 add_executable( fbexample ${fb_SRCS} )
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     qt5_use_modules( fbexample Core Widgets Network )
     target_link_libraries( fbexample o2 )
-else(WITH_QT5)
+else(o2_WITH_QT5)
     target_link_libraries( fbexample ${QT_LIBRARIES} o2 )
-endif(WITH_QT5)
+endif(o2_WITH_QT5)

--- a/examples/twitterdemo/CMakeLists.txt
+++ b/examples/twitterdemo/CMakeLists.txt
@@ -6,21 +6,21 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     # Qt5 packages find their own dependencies.
     find_package(Qt5Core    REQUIRED)
     find_package(Qt5Widgets REQUIRED)
     find_package(Qt5Script  REQUIRED)
     find_package(Qt5Network REQUIRED)
-else(WITH_QT5)
+else(o2_WITH_QT5)
     set(QT_USE_QTNETWORK true)
     set(QT_USE_QTSCRIPT true)
     find_package(Qt4 REQUIRED)
-endif(WITH_QT5)
+endif(o2_WITH_QT5)
 
-if (NOT WITH_QT5)
+if (NOT o2_WITH_QT5)
     include( ${QT_USE_FILE} )
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
  
 include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} "../../src" )
 
@@ -29,15 +29,15 @@ set(fb_SRCS
     tweeter.cpp
 )
 
-if(NOT WITH_QT5)
+if(NOT o2_WITH_QT5)
     add_definitions(${QT4_DEFINITIONS})
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
 
 add_executable( twitterexample ${fb_SRCS} )
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     qt5_use_modules( twitterexample Core Widgets Network )
     target_link_libraries( twitterexample o2 )
-else(WITH_QT5)
+else(o2_WITH_QT5)
     target_link_libraries( twitterexample ${QT_LIBRARIES} o2 )
-endif(WITH_QT5)
+endif(o2_WITH_QT5)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,18 +6,18 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     find_package(Qt5 COMPONENTS Core Network REQUIRED)
-else(WITH_QT5)
+else(o2_WITH_QT5)
     set(QT_USE_QTNETWORK true)
     set(QT_USE_QTSCRIPT true)
     find_package(Qt4 REQUIRED)
-endif(WITH_QT5)
+endif(o2_WITH_QT5)
 #find_package(QJson REQUIRED)
 
-if (NOT WITH_QT5)
+if (NOT o2_WITH_QT5)
     include( ${QT_USE_FILE} )
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
 
 set( o2_SRCS
     o2.cpp
@@ -31,72 +31,72 @@ set( o2_SRCS
     o0globals.h
 )
 
-if(WITH_TWITTER OR WITH_DROPBOX OR WITH_FLICKR)
+if(o2_WITH_OAUTH1)
     set( o2_SRCS
         ${o2_SRCS}
         o1.cpp
         o1requestor.cpp
     )
-endif(WITH_TWITTER OR WITH_DROPBOX OR WITH_FLICKR)
+endif(o2_WITH_OAUTH1)
 
-if(WITH_TWITTER)
+if(o2_WITH_TWITTER)
     set( o2_SRCS
         ${o2_SRCS}
         o1twitter.h
         oxtwitter.cpp
     )
-endif(WITH_TWITTER)
+endif(o2_WITH_TWITTER)
 
-if(WITH_DROPBOX)
+if(o2_WITH_DROPBOX)
     set( o2_SRCS
         ${o2_SRCS}
         o1dropbox.h
     )
-endif(WITH_DROPBOX)
+endif(o2_WITH_DROPBOX)
 
-if(WITH_GOOGLE)
+if(o2_WITH_GOOGLE)
     set( o2_SRCS
         ${o2_SRCS}
         o2gft.cpp
     )
-endif(WITH_GOOGLE)
+endif(o2_WITH_GOOGLE)
 
-if(WITH_FACEBOOK)
+if(o2_WITH_FACEBOOK)
     set( o2_SRCS
         ${o2_SRCS}
         o2facebook.cpp
     )
-endif(WITH_FACEBOOK)
+endif(o2_WITH_FACEBOOK)
 
-if(WITH_SKYDRIVE)
+if(o2_WITH_SKYDRIVE)
     set( o2_SRCS
         ${o2_SRCS}
         o2skydrive.cpp
     )
-endif(WITH_SKYDRIVE)
+endif(o2_WITH_SKYDRIVE)
 
-if(WITH_FLICKR)
+if(o2_WITH_FLICKR)
     set( o2_SRCS
         ${o2_SRCS}
         o1flickr.h
     )
-endif(WITH_FLICKR)
+endif(o2_WITH_FLICKR)
 
-if(WITH_HUBIC)
+if(o2_WITH_HUBIC)
     set( o2_SRCS
         ${o2_SRCS}
         o2hubic.cpp
     )
-endif(WITH_HUBIC)
+endif(o2_WITH_HUBIC)
 
-if(NOT WITH_QT5)
+if(NOT o2_WITH_QT5)
     add_definitions(${QT4_DEFINITIONS})
-endif(NOT WITH_QT5)
+endif(NOT o2_WITH_QT5)
 
 add_library( o2 ${o2_SRCS} )
 
-if(WITH_QT5)
+if(o2_WITH_QT5)
     target_link_libraries( o2 Qt5::Core Qt5::Network)
-else(WITH_QT5)
+else(o2_WITH_QT5)
     target_link_libraries( o2 ${QT_LIBRARIES} )
-endif(WITH_QT5)
+endif(o2_WITH_QT5)


### PR DESCRIPTION
This PR allows build options to be set via a CMake GUI frontend and provides a separate option for including generic OAuth1 code.