### PR TITLE
Add `o2_SHOW_TRACE` option to enable trace output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(o2)
 
 option(o2_WITH_QT5 "Use Qt5" ON)
 
+option(o2_SHOW_TRACE "Show debugging messages" OFF)
+if(NOT o2_SHOW_TRACE)
+  add_definitions(-DQT_NO_DEBUG_OUTPUT=1)
+endif()
+
 option(o2_WITH_TWITTER "Authenticate with Twitter" OFF)
 option(o2_WITH_DROPBOX "Authenticate with Dropbox" OFF)
 option(o2_WITH_GOOGLE "Authenticate with Google" OFF)

--- a/src/o0baseauth.cpp
+++ b/src/o0baseauth.cpp
@@ -5,9 +5,6 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 
-#define trace() if (1) qDebug()
-// define trace() if (0) qDebug()
-
 static const quint16 DefaultLocalPort = 1965;
 
 O0BaseAuth::O0BaseAuth(QObject *parent): QObject(parent) {
@@ -31,12 +28,12 @@ void O0BaseAuth::setStore(O0AbstractStore *store) {
 bool O0BaseAuth::linked() {
     QString key = QString(O2_KEY_LINKED).arg(clientId_);
     bool result = !store_->value(key).isEmpty();
-    trace() << "O0BaseAuth::linked:" << (result? "Yes": "No");
+    qDebug() << "O0BaseAuth::linked:" << (result? "Yes": "No");
     return result;
 }
 
 void O0BaseAuth::setLinked(bool v) {
-    trace() << "O0BaseAuth::setLinked:" << (v? "true": "false");
+    qDebug() << "O0BaseAuth::setLinked:" << (v? "true": "false");
     bool oldValue = linked();
     QString key = QString(O2_KEY_LINKED).arg(clientId_);
     store_->setValue(key, v? "1": "");
@@ -90,7 +87,7 @@ int O0BaseAuth::localPort() {
 }
 
 void O0BaseAuth::setLocalPort(int value) {
-    trace() << "O0BaseAuth::setLocalPort:" << value;
+    qDebug() << "O0BaseAuth::setLocalPort:" << value;
     localPort_ = value;
     emit localPortChanged();
 }

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -20,9 +20,6 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 
-#define trace() if (1) qDebug()
-// #define trace() if (0) qDebug()
-
 O1::O1(QObject *parent): O0BaseAuth(parent) {
     setSignatureMethod(O2_SIGNATURE_TYPE_HMAC_SHA1);
     manager_ = new QNetworkAccessManager(this);
@@ -80,12 +77,12 @@ QString O1::signatureMethod() {
 }
 
 void O1::setSignatureMethod(const QString &value) {
-    trace() << "O1::setSignatureMethod: " << value;
+    qDebug() << "O1::setSignatureMethod: " << value;
     signatureMethod_ = value;
 }
 
 void O1::unlink() {
-    trace() << "O1::unlink";
+    qDebug() << "O1::unlink";
     setLinked(false);
     setToken("");
     setTokenSecret("");
@@ -190,9 +187,9 @@ QByteArray O1::generateSignature(const QList<O0RequestParameter> headers, const 
 }
 
 void O1::link() {
-    trace() << "O1::link";
+    qDebug() << "O1::link";
     if (linked()) {
-        trace() << "O1::link: Linked already";
+        qDebug() << "O1::link: Linked already";
         emit linkingSucceeded();
         return;
     }
@@ -247,7 +244,7 @@ void O1::onTokenRequestError(QNetworkReply::NetworkError error) {
 }
 
 void O1::onTokenRequestFinished() {
-    trace() << "O1::onTokenRequestFinished";
+    qDebug() << "O1::onTokenRequestFinished";
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     reply->deleteLater();
     if (reply->error() != QNetworkReply::NoError) {
@@ -286,7 +283,7 @@ void O1::onTokenRequestFinished() {
 }
 
 void O1::onVerificationReceived(QMap<QString, QString> params) {
-    trace() << "O1::onVerificationReceived";
+    qDebug() << "O1::onVerificationReceived";
     emit closeBrowser();
     verifier_ = params.value(O2_OAUTH_VERFIER, "");
     if (params.value(O2_OAUTH_TOKEN) == requestToken_) {
@@ -299,7 +296,7 @@ void O1::onVerificationReceived(QMap<QString, QString> params) {
 }
 
 void O1::exchangeToken() {
-    trace() << "O1::exchangeToken";
+    qDebug() << "O1::exchangeToken";
 
     // Create token exchange request
     QNetworkRequest request(accessTokenUrl());
@@ -328,7 +325,7 @@ void O1::onTokenExchangeError(QNetworkReply::NetworkError error) {
 }
 
 void O1::onTokenExchangeFinished() {
-    trace() << "O1::onTokenExchangeFinished";
+    qDebug() << "O1::onTokenExchangeFinished";
 
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     reply->deleteLater();

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -25,9 +25,6 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 
-#define trace() if (1) qDebug()
-// define trace() if (0) qDebug()
-
 /// Parse JSON data into a QVariantMap
 static QVariantMap parseTokenResponse(const QByteArray &data) {
 #if QT_VERSION >= 0x050000
@@ -143,10 +140,10 @@ void O2::setRefreshTokenUrl(const QString &value) {
 }
 
 void O2::link() {
-    trace() << "O2::link";
+    qDebug() << "O2::link";
 
     if (linked()) {
-        trace() << "O2::link: Linked already";
+        qDebug() << "O2::link: Linked already";
         emit linkingSucceeded();
         return;
     }
@@ -176,7 +173,7 @@ void O2::link() {
         // Show authentication URL with a web browser
         QUrl url(requestUrl_);
         addQueryParametersToUrl(url, parameters);
-        trace() << "O2::link: Emit openBrowser" << url.toString();
+        qDebug() << "O2::link: Emit openBrowser" << url.toString();
         emit openBrowser(url);
     } else if (grantFlow_ == GrantFlowResourceOwnerPasswordCredentials) {
         QList<O0RequestParameter> parameters;
@@ -200,7 +197,7 @@ void O2::link() {
 }
 
 void O2::unlink() {
-    trace() << "O2::unlink";
+    qDebug() << "O2::unlink";
     setLinked(false);
     setToken(QString());
     setRefreshToken(QString());
@@ -210,8 +207,8 @@ void O2::unlink() {
 }
 
 void O2::onVerificationReceived(const QMap<QString, QString> response) {
-    trace() << "O2::onVerificationReceived:" << response;
-    trace() << "O2::onVerificationReceived: Emitting closeBrowser()";
+    qDebug() << "O2::onVerificationReceived:" << response;
+    qDebug() << "O2::onVerificationReceived: Emitting closeBrowser()";
     emit closeBrowser();
 
     if (response.contains("error")) {
@@ -256,7 +253,7 @@ void O2::setCode(const QString &c) {
 }
 
 void O2::onTokenReplyFinished() {
-    trace() << "O2::onTokenReplyFinished";
+    qDebug() << "O2::onTokenReplyFinished";
     QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
     if (tokenReply->error() == QNetworkReply::NoError) {
         QByteArray replyData = tokenReply->readAll();
@@ -268,7 +265,7 @@ void O2::onTokenReplyFinished() {
             bool ok = false;
             int expiresIn = tokens.take(O2_OAUTH2_EXPIRES_IN).toInt(&ok);
             if (ok) {
-                trace() << "O2::onTokenReplyFinished: Token expires in" << expiresIn << "seconds";
+                qDebug() << "O2::onTokenReplyFinished: Token expires in" << expiresIn << "seconds";
                 setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn);
             }
             setRefreshToken(tokens.take(O2_OAUTH2_REFRESH_TOKEN).toString());
@@ -287,7 +284,7 @@ void O2::onTokenReplyFinished() {
 void O2::onTokenReplyError(QNetworkReply::NetworkError error) {
     QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
     qWarning() << "O2::onTokenReplyError: " << error << ": " << tokenReply->errorString();
-    trace() << "O2::onTokenReplyError: " << tokenReply->readAll();
+    qDebug() << "O2::onTokenReplyError: " << tokenReply->readAll();
     setToken(QString());
     setRefreshToken(QString());
     timedReplies_.remove(tokenReply);
@@ -325,13 +322,13 @@ QString O2::refreshToken() {
 }
 
 void O2::setRefreshToken(const QString &v) {
-    trace() << "O2::setRefreshToken" << v.left(4) << "...";
+    qDebug() << "O2::setRefreshToken" << v.left(4) << "...";
     QString key = QString(O2_KEY_REFRESH_TOKEN).arg(clientId_);
     store_->setValue(key, v);
 }
 
 void O2::refresh() {
-    trace() << "O2::refresh: Token: ..." << refreshToken().right(7);
+    qDebug() << "O2::refresh: Token: ..." << refreshToken().right(7);
 
     if (refreshToken().isEmpty()) {
         qWarning() << "O2::refresh: No refresh token";
@@ -361,7 +358,7 @@ void O2::refresh() {
 
 void O2::onRefreshFinished() {
     QNetworkReply *refreshReply = qobject_cast<QNetworkReply *>(sender());
-    trace() << "O2::onRefreshFinished: Error" << (int)refreshReply->error() << refreshReply->errorString();
+    qDebug() << "O2::onRefreshFinished: Error" << (int)refreshReply->error() << refreshReply->errorString();
     if (refreshReply->error() == QNetworkReply::NoError) {
         QByteArray reply = refreshReply->readAll();
         QVariantMap tokens = parseTokenResponse(reply);
@@ -372,7 +369,7 @@ void O2::onRefreshFinished() {
         setLinked(true);
         emit linkingSucceeded();
         emit refreshFinished(QNetworkReply::NoError);
-        trace() << " New token expires in" << expires() << "seconds";
+        qDebug() << " New token expires in" << expires() << "seconds";
     }
     refreshReply->deleteLater();
 }

--- a/src/o2facebook.cpp
+++ b/src/o2facebook.cpp
@@ -15,16 +15,13 @@ static const char *FbEndpoint = "https://graph.facebook.com/oauth/authorize?disp
 static const char *FbTokenUrl = "https://graph.facebook.com/oauth/access_token";
 static const char *FbExpiresKey = "expires";
 
-#define trace() if (1) qDebug()
-// #define trace() if (0) qDebug()
-
 O2Facebook::O2Facebook(QObject *parent): O2(parent) {
     setRequestUrl(FbEndpoint);
     setTokenUrl(FbTokenUrl);
 }
 
 void O2Facebook::onVerificationReceived(const QMap<QString, QString> response) {
-    trace() << "O2Facebook::onVerificationReceived: Emitting closeBrowser()";
+    qDebug() << "O2Facebook::onVerificationReceived: Emitting closeBrowser()";
     emit closeBrowser();
 
     if (response.contains("error")) {
@@ -65,7 +62,7 @@ void O2Facebook::onVerificationReceived(const QMap<QString, QString> response) {
 }
 
 void O2Facebook::onTokenReplyFinished() {
-    trace() << "O2Facebook::onTokenReplyFinished";
+    qDebug() << "O2Facebook::onTokenReplyFinished";
 
     QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
     if (tokenReply->error() == QNetworkReply::NoError) {

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -13,9 +13,6 @@
 
 #include "o2replyserver.h"
 
-#define trace() if (1) qDebug()
-// #define trace() if (0) qDebug()
-
 O2ReplyServer::O2ReplyServer(QObject *parent): QTcpServer(parent) {
     connect(this, SIGNAL(newConnection()), this, SLOT(onIncomingConnection()));
     replyContent_ = "<HTML></HTML>";
@@ -28,7 +25,7 @@ void O2ReplyServer::onIncomingConnection() {
 }
 
 void O2ReplyServer::onBytesReady() {
-    trace() << "O2ReplyServer::onBytesReady";
+    qDebug() << "O2ReplyServer::onBytesReady";
     QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
     if (!socket) {
         return;
@@ -48,7 +45,7 @@ void O2ReplyServer::onBytesReady() {
 }
 
 QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
-    trace() << "O2ReplyServer::parseQueryParams";
+    qDebug() << "O2ReplyServer::parseQueryParams";
 
     QString splitGetLine = QString(*data).split("\r\n").first();
     splitGetLine.remove("GET ");

--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -8,9 +8,6 @@
 #include "o2.h"
 #include "o0globals.h"
 
-#define trace() if (1) qDebug()
-// define trace() if (0) qDebug()
-
 O2Requestor::O2Requestor(QNetworkAccessManager *manager, O2 *authenticator, QObject *parent): QObject(parent), reply_(NULL), status_(Idle) {
     manager_ = manager;
     authenticator_ = authenticator;
@@ -98,7 +95,7 @@ void O2Requestor::onRequestError(QNetworkReply::NetworkError error) {
     }
     int httpStatus = reply_->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     qWarning() << "O2Requestor::onRequestError: HTTP status" << httpStatus << reply_->attribute(QNetworkRequest::HttpReasonPhraseAttribute).toString();
-    trace() << reply_->readAll();
+    qDebug() << reply_->readAll();
     if ((status_ == Requesting) && (httpStatus == 401)) {
         // Call O2::refresh. Note the O2 instance might live in a different thread
         if (QMetaObject::invokeMethod(authenticator_, "refresh")) {

--- a/src/o2skydrive.cpp
+++ b/src/o2skydrive.cpp
@@ -10,9 +10,6 @@
 #include "o2skydrive.h"
 #include "o0globals.h"
 
-#define trace() if (1) qDebug()
-// define trace() if (0) qDebug()
-
 O2Skydrive::O2Skydrive(QObject *parent): O2(parent) {
     setRequestUrl("https://login.live.com/oauth20_authorize.srf");
     setTokenUrl("https://login.live.com/oauth20_token.srf");
@@ -20,9 +17,9 @@ O2Skydrive::O2Skydrive(QObject *parent): O2(parent) {
 }
 
 void O2Skydrive::link() {
-    trace() << "O2Skydrive::link";
+    qDebug() << "O2Skydrive::link";
     if (linked()) {
-        trace() << "O2kydrive::link: Linked already";
+        qDebug() << "O2kydrive::link: Linked already";
         return;
     }
 
@@ -55,7 +52,7 @@ void O2Skydrive::link() {
 }
 
 void O2Skydrive::redirected(const QUrl &url) {
-    trace() << "O2Skydrive::redirected" << url;
+    qDebug() << "O2Skydrive::redirected" << url;
 
     emit closeBrowser();
 
@@ -69,7 +66,7 @@ void O2Skydrive::redirected(const QUrl &url) {
         urlCode = query.queryItemValue(O2_OAUTH2_GRANT_TYPE_CODE);
 #endif
         if (urlCode.isEmpty()) {
-            trace() << "O2Skydrive::redirected: Code not received";
+            qDebug() << "O2Skydrive::redirected: Code not received";
             emit linkingFailed();
             return;
         }
@@ -104,7 +101,7 @@ void O2Skydrive::redirected(const QUrl &url) {
                 }
                 QString key = item.left(index);
                 QString value = item.mid(index + 1);
-                trace() << "O2Skydrive::redirected: Got" << key;
+                qDebug() << "O2Skydrive::redirected: Got" << key;
                 if (key == O2_OAUTH2_ACCESS_TOKEN) {
                     urlToken = value;
                 } else if (key == O2_OAUTH2_EXPIRES_IN) {

--- a/src/oxtwitter.cpp
+++ b/src/oxtwitter.cpp
@@ -4,8 +4,6 @@
 #include "oxtwitter.h"
 #include "o0globals.h"
 
-#define trace() if (1) qDebug()
-
 const char XAUTH_USERNAME[] = "x_auth_username";
 const char XAUTH_PASSWORD[] = "x_auth_password";
 const char XAUTH_MODE[] = "x_auth_mode";
@@ -33,9 +31,9 @@ void OXTwitter::setPassword(const QString &password) {
 }
 
 void OXTwitter::link() {
-    trace() << "OXTwitter::link";
+    qDebug() << "OXTwitter::link";
     if (linked()) {
-        trace() << "Linked already";
+        qDebug() << "Linked already";
         return;
     }
 


### PR DESCRIPTION
Here is another way to disable trace by default (instead of having it in the public API).

Thanks.