### PR TITLE
Fixes for several compile warnings and errors

### DIFF
--- a/examples/facebookdemo/fbdemo.h
+++ b/examples/facebookdemo/fbdemo.h
@@ -12,16 +12,16 @@ class FBDemo : public QObject
 public:
     explicit FBDemo(QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
     void extraTokensReady(const QVariantMap &extraTokens);
     void linkingFailed();
     void linkingSucceeded();
 
-public slots:
+public Q_SLOTS:
     void doOAuth(O2::GrantFlow grantFlowType);
     void validateToken();
 
-private slots:
+private Q_SLOTS:
     void onLinkedChanged();
     void onLinkingSucceeded();
     void onOpenBrowser(const QUrl &url);

--- a/examples/facebookdemo/main.cpp
+++ b/examples/facebookdemo/main.cpp
@@ -22,7 +22,7 @@ class Helper : public QObject {
 public:
     Helper() : QObject(), fbdemo_(this), waitForMsg_(false), msg_(QString()) {}
 
-public slots:
+public Q_SLOTS:
     void processArgs() {
         QStringList argList = qApp->arguments();
         QByteArray help = QString(USAGE).arg(OPT_OAUTH_CODE,

--- a/examples/sialis/twitterapi.h
+++ b/examples/sialis/twitterapi.h
@@ -26,10 +26,10 @@ public:
     explicit TwitterApi(QObject *parent = 0);
     virtual ~TwitterApi();
 
-public slots:
+public Q_SLOTS:
     Q_INVOKABLE virtual void requestTweets();
 
-signals:
+Q_SIGNALS:
     void tweetModelChanged();
 
 protected:
@@ -37,7 +37,7 @@ protected:
     TweetModel *tweetModel_;
     QNetworkAccessManager *manager_;
 
-protected slots:
+protected Q_SLOTS:
     void tweetsReceived();
     void requestFailed(QNetworkReply::NetworkError error);
 };

--- a/examples/twitterdemo/main.cpp
+++ b/examples/twitterdemo/main.cpp
@@ -29,7 +29,7 @@ class Helper : public QObject {
 public:
     Helper() : QObject(), tweeter_(this), waitForMsg_(false), msg_(QString()) {}
 
-public slots:
+public Q_SLOTS:
     void processArgs() {
         QStringList argList = qApp->arguments();
         QByteArray help = QString(USAGE).arg(OPT_OAUTH,
@@ -87,7 +87,7 @@ public slots:
         }
     }
 
-private slots:
+private Q_SLOTS:
     void postStatusUpdate(const QString& msg) {
         connect(&tweeter_, SIGNAL(statusPosted()), qApp, SLOT(quit()));
         tweeter_.postStatusUpdate(msg);

--- a/examples/twitterdemo/tweeter.h
+++ b/examples/twitterdemo/tweeter.h
@@ -15,18 +15,18 @@ class Tweeter : public QObject
 public:
     explicit Tweeter(QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
     void extraTokensReady(const QVariantMap &extraTokens);
     void linkingFailed();
     void linkingSucceeded();
     void statusPosted();
 
-public slots:
+public Q_SLOTS:
     void doOAuth();
     void doXAuth(const QString &username, const QString &password);
     void postStatusUpdate(const QString &message);
 
-private slots:
+private Q_SLOTS:
     void onLinkedChanged();
     void onLinkingSucceeded();
     void onOpenBrowser(const QUrl &url);

--- a/src/o0baseauth.h
+++ b/src/o0baseauth.h
@@ -60,14 +60,14 @@ public:
     /// Construct query string from list of headers
     static QByteArray createQueryParameters(const QList<O0RequestParameter> &parameters);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link() = 0;
 
     /// De-authenticate.
     Q_INVOKABLE virtual void unlink() = 0;
 
-signals:
+Q_SIGNALS:
     /// Emitted when client needs to open a web browser window, with the given URL.
     void openBrowser(const QUrl &url);
 

--- a/src/o0settingsstore.h
+++ b/src/o0settingsstore.h
@@ -29,7 +29,7 @@ public:
     /// Set a string value for a key
     void setValue(const QString &key, const QString &value);
 
-signals:
+Q_SIGNALS:
     // Property change signals
     void groupKeyChanged();
 

--- a/src/o0simplecrypt.h
+++ b/src/o0simplecrypt.h
@@ -209,7 +209,7 @@ public:
                     CryptoFlagChecksum = 0x02,
                     CryptoFlagHash = 0x04
                    };
-    Q_DECLARE_FLAGS(CryptoFlags, CryptoFlag);
+    Q_DECLARE_FLAGS(CryptoFlags, CryptoFlag)
 private:
 
     void splitKey();

--- a/src/o1.h
+++ b/src/o1.h
@@ -77,20 +77,20 @@ public:
     /// Build a concatenated/percent-encoded string from a list of headers.
     static QByteArray encodeHeaders(const QList<O0RequestParameter> &headers);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
     /// De-authenticate.
     Q_INVOKABLE virtual void unlink();
 
-signals:
+Q_SIGNALS:
     void requestTokenUrlChanged();
     void authorizeUrlChanged();
     void accessTokenUrlChanged();
     void signatureMethodChanged();
 
-protected slots:
+protected Q_SLOTS:
     /// Handle verification received from the reply server.
     virtual void onVerificationReceived(QMap<QString,QString> params);
 

--- a/src/o1requestor.h
+++ b/src/o1requestor.h
@@ -18,7 +18,7 @@ class O1Requestor: public QObject {
 public:
     explicit O1Requestor(QNetworkAccessManager *manager, O1 *authenticator, QObject *parent = 0);
 
-public slots:
+public Q_SLOTS:
     /// Make a GET request.
     /// @param  req                 Network request.
     /// @param  signingParameters   Extra (non-OAuth) parameters participating in signing.

--- a/src/o1timedreply.h
+++ b/src/o1timedreply.h
@@ -11,13 +11,13 @@ class O1TimedReply: public QTimer {
 public:
     explicit O1TimedReply(QNetworkReply *parent, int pTimeout=60*1000);
 
-signals:
+Q_SIGNALS:
     /// Emitted when we have timed out waiting for the network reply.
     void error(QNetworkReply::NetworkError);
     /// Emitted when the network reply has responded.
     void finished();
 
-private slots:
+private Q_SLOTS:
     void onFinished();
     void onTimeout();
 };

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -222,8 +222,10 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         setCode(response.value(QString(O2_OAUTH2_GRANT_TYPE_CODE)));
 
         // Exchange access code for access/refresh tokens
-        QNetworkRequest tokenRequest(tokenUrl_.toString() +
-              (apiKey_.isEmpty() ? "" : ("?" + QString(O2_OAUTH2_API_KEY) + "=" + apiKey_)));
+        QString query;
+        if(!apiKey_.isEmpty())
+            query = QString("?" + QString(O2_OAUTH2_API_KEY) + "=" + apiKey_);
+        QNetworkRequest tokenRequest(QUrl(tokenUrl_.toString() + query));
         tokenRequest.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
         QMap<QString, QString> parameters;
         parameters.insert(O2_OAUTH2_GRANT_TYPE_CODE, code());

--- a/src/o2.h
+++ b/src/o2.h
@@ -99,7 +99,7 @@ public:
     /// Get token expiration time (seconds from Epoch).
     int expires();
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
@@ -109,7 +109,7 @@ public slots:
     /// Refresh token.
     Q_INVOKABLE void refresh();
 
-signals:
+Q_SIGNALS:
     /// Emitted when a token refresh has been completed or failed.
     void refreshFinished(QNetworkReply::NetworkError error);
 
@@ -122,7 +122,7 @@ signals:
     void refreshTokenUrlChanged();
     void tokenUrlChanged();
 
-protected slots:
+protected Q_SLOTS:
     /// Handle verification response.
     virtual void onVerificationReceived(QMap<QString, QString>);
 

--- a/src/o2facebook.h
+++ b/src/o2facebook.h
@@ -10,7 +10,7 @@ class O2Facebook: public O2 {
 public:
     explicit O2Facebook(QObject *parent = 0);
 
-protected slots:
+protected Q_SLOTS:
     void onVerificationReceived(QMap<QString, QString>);
     virtual void onTokenReplyFinished();
 };

--- a/src/o2reply.h
+++ b/src/o2reply.h
@@ -15,10 +15,10 @@ class O2Reply: public QTimer {
 public:
     O2Reply(QNetworkReply *reply, int timeOut = 60 * 1000, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
     void error(QNetworkReply::NetworkError);
 
-public slots:
+public Q_SLOTS:
     /// When time out occurs, the QNetworkReply's error() signal is triggered.
     void onTimeOut();
 

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -18,10 +18,10 @@ public:
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
-signals:
+Q_SIGNALS:
     void verificationReceived(QMap<QString, QString>);
 
-public slots:
+public Q_SLOTS:
     void onIncomingConnection();
     void onBytesReady();
     QMap<QString, QString> parseQueryParams(QByteArray *data);

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -20,7 +20,7 @@ public:
     explicit O2Requestor(QNetworkAccessManager *manager, O2 *authenticator, QObject *parent = 0);
     ~O2Requestor();
 
-public slots:
+public Q_SLOTS:
     /// Make a GET request.
     /// @return Request ID or -1 if there are too many requests in the queue.
     int get(const QNetworkRequest &req);
@@ -33,14 +33,14 @@ public slots:
     /// @return Request ID or -1 if there are too many requests in the queue.
     int put(const QNetworkRequest &req, const QByteArray &data);
 
-signals:
+Q_SIGNALS:
     /// Emitted when a request has been completed or failed.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data);
 
     /// Emitted when an upload has progressed.
     void uploadProgress(int id, qint64 bytesSent, qint64 bytesTotal);
 
-protected slots:
+protected Q_SLOTS:
     /// Handle refresh completion.
     void onRefreshFinished(QNetworkReply::NetworkError error);
 

--- a/src/o2skydrive.h
+++ b/src/o2skydrive.h
@@ -10,7 +10,7 @@ class O2Skydrive: public O2 {
 public:
     explicit O2Skydrive(QObject *parent = 0);
 
-public slots:
+public Q_SLOTS:
     Q_INVOKABLE void link();
     Q_INVOKABLE virtual void redirected(const QUrl &url);
 };

--- a/src/oxtwitter.h
+++ b/src/oxtwitter.h
@@ -20,11 +20,11 @@ public:
     QString password();
     void setPassword(const QString &password);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
-signals:
+Q_SIGNALS:
     void usernameChanged();
     void passwordChanged();
 


### PR DESCRIPTION
Many projects build without Qt keywords enabled, so ```signals``` and ```slots``` are syntactically invalid. Also fix a compile error and warnings about a superfluous semicolon.