### PR TITLE
Fixes for several compile warnings and errors - attempt 2

### DIFF
--- a/src/o0baseauth.cpp
+++ b/src/o0baseauth.cpp
@@ -38,7 +38,7 @@ void O0BaseAuth::setLinked(bool v) {
     QString key = QString(O2_KEY_LINKED).arg(clientId_);
     store_->setValue(key, v? "1": "");
     if (oldValue != v) {
-        emit linkedChanged();
+        Q_EMIT linkedChanged();
     }
 }
 
@@ -50,7 +50,7 @@ QString O0BaseAuth::tokenSecret() {
 void O0BaseAuth::setTokenSecret(const QString &v) {
     QString key = QString(O2_KEY_TOKEN_SECRET).arg(clientId_);
     store_->setValue(key, v);
-    emit tokenSecretChanged();
+    Q_EMIT tokenSecretChanged();
 }
 
 QString O0BaseAuth::token() {
@@ -61,7 +61,7 @@ QString O0BaseAuth::token() {
 void O0BaseAuth::setToken(const QString &v) {
     QString key = QString(O2_KEY_TOKEN).arg(clientId_);
     store_->setValue(key, v);
-    emit tokenChanged();
+    Q_EMIT tokenChanged();
 }
 
 QString O0BaseAuth::clientId() {
@@ -70,7 +70,7 @@ QString O0BaseAuth::clientId() {
 
 void O0BaseAuth::setClientId(const QString &value) {
     clientId_ = value;
-    emit clientIdChanged();
+    Q_EMIT clientIdChanged();
 }
 
 QString O0BaseAuth::clientSecret() {
@@ -79,7 +79,7 @@ QString O0BaseAuth::clientSecret() {
 
 void O0BaseAuth::setClientSecret(const QString &value) {
     clientSecret_ = value;
-    emit clientSecretChanged();
+    Q_EMIT clientSecretChanged();
 }
 
 int O0BaseAuth::localPort() {
@@ -89,7 +89,7 @@ int O0BaseAuth::localPort() {
 void O0BaseAuth::setLocalPort(int value) {
     qDebug() << "O0BaseAuth::setLocalPort:" << value;
     localPort_ = value;
-    emit localPortChanged();
+    Q_EMIT localPortChanged();
 }
 
 QVariantMap O0BaseAuth::extraTokens() {
@@ -108,7 +108,7 @@ void O0BaseAuth::setExtraTokens(QVariantMap extraTokens) {
     stream << extraTokens;
     QString key = QString(O2_KEY_EXTRA_TOKENS).arg(clientId_);
     store_->setValue(key, bytes.toBase64());
-    emit extraTokensChanged();
+    Q_EMIT extraTokensChanged();
 }
 
 QByteArray O0BaseAuth::createQueryParameters(const QList<O0RequestParameter> &parameters) {

--- a/src/o0baseauth.h
+++ b/src/o0baseauth.h
@@ -60,14 +60,14 @@ public:
     /// Construct query string from list of headers
     static QByteArray createQueryParameters(const QList<O0RequestParameter> &parameters);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link() = 0;
 
     /// De-authenticate.
     Q_INVOKABLE virtual void unlink() = 0;
 
-signals:
+Q_SIGNALS:
     /// Emitted when client needs to open a web browser window, with the given URL.
     void openBrowser(const QUrl &url);
 

--- a/src/o0settingsstore.cpp
+++ b/src/o0settingsstore.cpp
@@ -27,7 +27,7 @@ void O0SettingsStore::setGroupKey(const QString &groupKey) {
         return;
     }
     groupKey_ = groupKey;
-    emit groupKeyChanged();
+    Q_EMIT groupKeyChanged();
 }
 
 QString O0SettingsStore::value(const QString &key, const QString &defaultValue) {

--- a/src/o0settingsstore.h
+++ b/src/o0settingsstore.h
@@ -29,7 +29,7 @@ public:
     /// Set a string value for a key
     void setValue(const QString &key, const QString &value);
 
-signals:
+Q_SIGNALS:
     // Property change signals
     void groupKeyChanged();
 

--- a/src/o0simplecrypt.h
+++ b/src/o0simplecrypt.h
@@ -209,7 +209,7 @@ public:
                     CryptoFlagChecksum = 0x02,
                     CryptoFlagHash = 0x04
                    };
-    Q_DECLARE_FLAGS(CryptoFlags, CryptoFlag);
+    Q_DECLARE_FLAGS(CryptoFlags, CryptoFlag)
 private:
 
     void splitKey();

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -35,7 +35,7 @@ QUrl O1::requestTokenUrl() {
 
 void O1::setRequestTokenUrl(const QUrl &v) {
     requestTokenUrl_ = v;
-    emit requestTokenUrlChanged();
+    Q_EMIT requestTokenUrlChanged();
 }
 
 QList<O0RequestParameter> O1::requestParameters() {
@@ -60,7 +60,7 @@ QUrl O1::authorizeUrl() {
 
 void O1::setAuthorizeUrl(const QUrl &value) {
     authorizeUrl_ = value;
-    emit authorizeUrlChanged();
+    Q_EMIT authorizeUrlChanged();
 }
 
 QUrl O1::accessTokenUrl() {
@@ -69,7 +69,7 @@ QUrl O1::accessTokenUrl() {
 
 void O1::setAccessTokenUrl(const QUrl &value) {
     accessTokenUrl_ = value;
-    emit accessTokenUrlChanged();
+    Q_EMIT accessTokenUrlChanged();
 }
 
 QString O1::signatureMethod() {
@@ -87,7 +87,7 @@ void O1::unlink() {
     setToken("");
     setTokenSecret("");
     setExtraTokens(QVariantMap());
-    emit linkingSucceeded();
+    Q_EMIT linkingSucceeded();
 }
 
 #if QT_VERSION < 0x050100
@@ -190,7 +190,7 @@ void O1::link() {
     qDebug() << "O1::link";
     if (linked()) {
         qDebug() << "O1::link: Linked already";
-        emit linkingSucceeded();
+        Q_EMIT linkingSucceeded();
         return;
     }
 
@@ -240,7 +240,7 @@ void O1::link() {
 void O1::onTokenRequestError(QNetworkReply::NetworkError error) {
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     qWarning() << "O1::onTokenRequestError:" << (int)error << reply->errorString() << reply->readAll();
-    emit linkingFailed();
+    Q_EMIT linkingFailed();
 }
 
 void O1::onTokenRequestFinished() {
@@ -264,7 +264,7 @@ void O1::onTokenRequestFinished() {
     QString oAuthCbConfirmed = response.value(O2_OAUTH_CALLBACK_CONFIRMED, "false");
     if (requestToken_.isEmpty() || requestTokenSecret_.isEmpty() || (oAuthCbConfirmed == "false")) {
         qWarning() << "O1::onTokenRequestFinished: No oauth_token, oauth_token_secret or oauth_callback_confirmed in response :" << data;
-        emit linkingFailed();
+        Q_EMIT linkingFailed();
         return;
     }
 
@@ -279,19 +279,19 @@ void O1::onTokenRequestFinished() {
     query.addQueryItem(O2_OAUTH_CALLBACK, callbackUrl().arg(replyServer_->serverPort()).toLatin1());
     url.setQuery(query);
 #endif
-    emit openBrowser(url);
+    Q_EMIT openBrowser(url);
 }
 
 void O1::onVerificationReceived(QMap<QString, QString> params) {
     qDebug() << "O1::onVerificationReceived";
-    emit closeBrowser();
+    Q_EMIT closeBrowser();
     verifier_ = params.value(O2_OAUTH_VERFIER, "");
     if (params.value(O2_OAUTH_TOKEN) == requestToken_) {
         // Exchange request token for access token
         exchangeToken();
     } else {
         qWarning() << "O1::onVerificationReceived: oauth_token missing or doesn't match";
-        emit linkingFailed();
+        Q_EMIT linkingFailed();
     }
 }
 
@@ -321,7 +321,7 @@ void O1::exchangeToken() {
 void O1::onTokenExchangeError(QNetworkReply::NetworkError error) {
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     qWarning() << "O1::onTokenExchangeError:" << (int)error << reply->errorString() << reply->readAll();
-    emit linkingFailed();
+    Q_EMIT linkingFailed();
 }
 
 void O1::onTokenExchangeFinished() {
@@ -349,10 +349,10 @@ void O1::onTokenExchangeFinished() {
             setExtraTokens(extraTokens);
         }
         setLinked(true);
-        emit linkingSucceeded();
+        Q_EMIT linkingSucceeded();
     } else {
         qWarning() << "O1::onTokenExchangeFinished: oauth_token or oauth_token_secret missing from response" << data;
-        emit linkingFailed();
+        Q_EMIT linkingFailed();
     }
 }
 

--- a/src/o1.h
+++ b/src/o1.h
@@ -77,20 +77,20 @@ public:
     /// Build a concatenated/percent-encoded string from a list of headers.
     static QByteArray encodeHeaders(const QList<O0RequestParameter> &headers);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
     /// De-authenticate.
     Q_INVOKABLE virtual void unlink();
 
-signals:
+Q_SIGNALS:
     void requestTokenUrlChanged();
     void authorizeUrlChanged();
     void accessTokenUrlChanged();
     void signatureMethodChanged();
 
-protected slots:
+protected Q_SLOTS:
     /// Handle verification received from the reply server.
     virtual void onVerificationReceived(QMap<QString,QString> params);
 

--- a/src/o1requestor.h
+++ b/src/o1requestor.h
@@ -18,7 +18,7 @@ class O1Requestor: public QObject {
 public:
     explicit O1Requestor(QNetworkAccessManager *manager, O1 *authenticator, QObject *parent = 0);
 
-public slots:
+public Q_SLOTS:
     /// Make a GET request.
     /// @param  req                 Network request.
     /// @param  signingParameters   Extra (non-OAuth) parameters participating in signing.

--- a/src/o1timedreply.cpp
+++ b/src/o1timedreply.cpp
@@ -12,9 +12,9 @@ O1TimedReply::O1TimedReply(QNetworkReply *parent, int pTimeout): QTimer(parent) 
 
 void O1TimedReply::onFinished() {
     stop();
-    emit finished();
+    Q_EMIT finished();
 }
 
 void O1TimedReply::onTimeout() {
-    emit error(QNetworkReply::TimeoutError);
+    Q_EMIT error(QNetworkReply::TimeoutError);
 }

--- a/src/o1timedreply.h
+++ b/src/o1timedreply.h
@@ -11,13 +11,13 @@ class O1TimedReply: public QTimer {
 public:
     explicit O1TimedReply(QNetworkReply *parent, int pTimeout=60*1000);
 
-signals:
+Q_SIGNALS:
     /// Emitted when we have timed out waiting for the network reply.
     void error(QNetworkReply::NetworkError);
     /// Emitted when the network reply has responded.
     void finished();
 
-private slots:
+private Q_SLOTS:
     void onFinished();
     void onTimeout();
 };

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -82,7 +82,7 @@ O2::GrantFlow O2::grantFlow() {
 
 void O2::setGrantFlow(O2::GrantFlow value) {
     grantFlow_ = value;
-    emit grantFlowChanged();
+    Q_EMIT grantFlowChanged();
 }
 
 QString O2::username() {
@@ -91,7 +91,7 @@ QString O2::username() {
 
 void O2::setUsername(const QString &value) {
     username_ = value;
-    emit usernameChanged();
+    Q_EMIT usernameChanged();
 }
 
 QString O2::password() {
@@ -100,7 +100,7 @@ QString O2::password() {
 
 void O2::setPassword(const QString &value) {
     password_ = value;
-    emit passwordChanged();
+    Q_EMIT passwordChanged();
 }
 
 QString O2::scope() {
@@ -109,7 +109,7 @@ QString O2::scope() {
 
 void O2::setScope(const QString &value) {
     scope_ = value;
-    emit scopeChanged();
+    Q_EMIT scopeChanged();
 }
 
 QString O2::requestUrl() {
@@ -118,7 +118,7 @@ QString O2::requestUrl() {
 
 void O2::setRequestUrl(const QString &value) {
     requestUrl_ = value;
-    emit requestUrlChanged();
+    Q_EMIT requestUrlChanged();
 }
 
 QString O2::tokenUrl() {
@@ -127,7 +127,7 @@ QString O2::tokenUrl() {
 
 void O2::setTokenUrl(const QString &value) {
     tokenUrl_= value;
-    emit tokenUrlChanged();
+    Q_EMIT tokenUrlChanged();
 }
 
 QString O2::refreshTokenUrl() {
@@ -136,7 +136,7 @@ QString O2::refreshTokenUrl() {
 
 void O2::setRefreshTokenUrl(const QString &value) {
     refreshTokenUrl_ = value;
-    emit refreshTokenUrlChanged();
+    Q_EMIT refreshTokenUrlChanged();
 }
 
 void O2::link() {
@@ -144,7 +144,7 @@ void O2::link() {
 
     if (linked()) {
         qDebug() << "O2::link: Linked already";
-        emit linkingSucceeded();
+        Q_EMIT linkingSucceeded();
         return;
     }
 
@@ -174,7 +174,7 @@ void O2::link() {
         QUrl url(requestUrl_);
         addQueryParametersToUrl(url, parameters);
         qDebug() << "O2::link: Emit openBrowser" << url.toString();
-        emit openBrowser(url);
+        Q_EMIT openBrowser(url);
     } else if (grantFlow_ == GrantFlowResourceOwnerPasswordCredentials) {
         QList<O0RequestParameter> parameters;
         parameters.append(O0RequestParameter(O2_OAUTH2_CLIENT_ID, clientId_.toUtf8()));
@@ -203,17 +203,17 @@ void O2::unlink() {
     setRefreshToken(QString());
     setExpires(0);
     setExtraTokens(QVariantMap());
-    emit linkingSucceeded();
+    Q_EMIT linkingSucceeded();
 }
 
 void O2::onVerificationReceived(const QMap<QString, QString> response) {
     qDebug() << "O2::onVerificationReceived:" << response;
     qDebug() << "O2::onVerificationReceived: Emitting closeBrowser()";
-    emit closeBrowser();
+    Q_EMIT closeBrowser();
 
     if (response.contains("error")) {
         qWarning() << "O2::onVerificationReceived: Verification failed: " << response;
-        emit linkingFailed();
+        Q_EMIT linkingFailed();
         return;
     }
 
@@ -274,10 +274,10 @@ void O2::onTokenReplyFinished() {
             setExtraTokens(tokens);
             timedReplies_.remove(tokenReply);
             setLinked(true);
-            emit linkingSucceeded();
+            Q_EMIT linkingSucceeded();
         } else {
             qWarning() << "O2::onTokenReplyFinished: oauth_token missing from response" << replyData;
-            emit linkingFailed();
+            Q_EMIT linkingFailed();
         }
     }
     tokenReply->deleteLater();
@@ -290,7 +290,7 @@ void O2::onTokenReplyError(QNetworkReply::NetworkError error) {
     setToken(QString());
     setRefreshToken(QString());
     timedReplies_.remove(tokenReply);
-    emit linkingFailed();
+    Q_EMIT linkingFailed();
 }
 
 QByteArray O2::buildRequestBody(const QMap<QString, QString> &parameters) {
@@ -369,8 +369,8 @@ void O2::onRefreshFinished() {
         setRefreshToken(tokens.value(O2_OAUTH2_REFRESH_TOKEN).toString());
         timedReplies_.remove(refreshReply);
         setLinked(true);
-        emit linkingSucceeded();
-        emit refreshFinished(QNetworkReply::NoError);
+        Q_EMIT linkingSucceeded();
+        Q_EMIT refreshFinished(QNetworkReply::NoError);
         qDebug() << " New token expires in" << expires() << "seconds";
     }
     refreshReply->deleteLater();
@@ -381,7 +381,7 @@ void O2::onRefreshError(QNetworkReply::NetworkError error) {
     qWarning() << "O2::onRefreshError: " << error;
     unlink();
     timedReplies_.remove(refreshReply);
-    emit refreshFinished(error);
+    Q_EMIT refreshFinished(error);
 }
 
 QString O2::localhostPolicy() const {

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -222,8 +222,10 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         setCode(response.value(QString(O2_OAUTH2_GRANT_TYPE_CODE)));
 
         // Exchange access code for access/refresh tokens
-        QNetworkRequest tokenRequest(tokenUrl_.toString() +
-              (apiKey_.isEmpty() ? "" : ("?" + QString(O2_OAUTH2_API_KEY) + "=" + apiKey_)));
+        QString query;
+        if(!apiKey_.isEmpty())
+            query = QString("?" + QString(O2_OAUTH2_API_KEY) + "=" + apiKey_);
+        QNetworkRequest tokenRequest(QUrl(tokenUrl_.toString() + query));
         tokenRequest.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
         QMap<QString, QString> parameters;
         parameters.insert(O2_OAUTH2_GRANT_TYPE_CODE, code());

--- a/src/o2.h
+++ b/src/o2.h
@@ -99,7 +99,7 @@ public:
     /// Get token expiration time (seconds from Epoch).
     int expires();
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
@@ -109,7 +109,7 @@ public slots:
     /// Refresh token.
     Q_INVOKABLE void refresh();
 
-signals:
+Q_SIGNALS:
     /// Emitted when a token refresh has been completed or failed.
     void refreshFinished(QNetworkReply::NetworkError error);
 
@@ -122,7 +122,7 @@ signals:
     void refreshTokenUrlChanged();
     void tokenUrlChanged();
 
-protected slots:
+protected Q_SLOTS:
     /// Handle verification response.
     virtual void onVerificationReceived(QMap<QString, QString>);
 

--- a/src/o2facebook.cpp
+++ b/src/o2facebook.cpp
@@ -22,14 +22,14 @@ O2Facebook::O2Facebook(QObject *parent): O2(parent) {
 
 void O2Facebook::onVerificationReceived(const QMap<QString, QString> response) {
     qDebug() << "O2Facebook::onVerificationReceived: Emitting closeBrowser()";
-    emit closeBrowser();
+    Q_EMIT closeBrowser();
 
     if (response.contains("error")) {
         qWarning() << "O2Facebook::onVerificationReceived: Verification failed";
         foreach (QString key, response.keys()) {
             qWarning() << "O2Facebook::onVerificationReceived:" << key << response.value(key);
         }
-        emit linkingFailed();
+        Q_EMIT linkingFailed();
         return;
     }
 
@@ -83,7 +83,7 @@ void O2Facebook::onTokenReplyFinished() {
         setExtraTokens(reply);
         timedReplies_.remove(tokenReply);
         setLinked(true);
-        emit linkingSucceeded();
+        Q_EMIT linkingSucceeded();
     } else {
         qWarning() << "O2Facebook::onTokenReplyFinished:" << tokenReply->errorString();
     }

--- a/src/o2facebook.h
+++ b/src/o2facebook.h
@@ -10,7 +10,7 @@ class O2Facebook: public O2 {
 public:
     explicit O2Facebook(QObject *parent = 0);
 
-protected slots:
+protected Q_SLOTS:
     void onVerificationReceived(QMap<QString, QString>);
     virtual void onTokenReplyFinished();
 };

--- a/src/o2reply.cpp
+++ b/src/o2reply.cpp
@@ -11,7 +11,7 @@ O2Reply::O2Reply(QNetworkReply *r, int timeOut, QObject *parent): QTimer(parent)
 }
 
 void O2Reply::onTimeOut() {
-    emit error(QNetworkReply::TimeoutError);
+    Q_EMIT error(QNetworkReply::TimeoutError);
 }
 
 O2ReplyList::~O2ReplyList() {

--- a/src/o2reply.h
+++ b/src/o2reply.h
@@ -15,10 +15,10 @@ class O2Reply: public QTimer {
 public:
     O2Reply(QNetworkReply *reply, int timeOut = 60 * 1000, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
     void error(QNetworkReply::NetworkError);
 
-public slots:
+public Q_SLOTS:
     /// When time out occurs, the QNetworkReply's error() signal is triggered.
     void onTimeOut();
 

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -41,7 +41,7 @@ void O2ReplyServer::onBytesReady() {
     QMap<QString, QString> queryParams = parseQueryParams(&data);
     socket->disconnectFromHost();
     close();
-    emit verificationReceived(queryParams);
+    Q_EMIT verificationReceived(queryParams);
 }
 
 QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -18,10 +18,10 @@ public:
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
-signals:
+Q_SIGNALS:
     void verificationReceived(QMap<QString, QString>);
 
-public slots:
+public Q_SLOTS:
     void onIncomingConnection();
     void onBytesReady();
     QMap<QString, QString> parseQueryParams(QByteArray *data);

--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -115,7 +115,7 @@ void O2Requestor::onUploadProgress(qint64 uploaded, qint64 total) {
     if (reply_ != qobject_cast<QNetworkReply *>(sender())) {
         return;
     }
-    emit uploadProgress(id_, uploaded, total);
+    Q_EMIT uploadProgress(id_, uploaded, total);
 }
 
 int O2Requestor::setup(const QNetworkRequest &req, QNetworkAccessManager::Operation operation) {
@@ -155,7 +155,7 @@ void O2Requestor::finish() {
     timedReplies_.remove(reply_);
     reply_->disconnect(this);
     reply_->deleteLater();
-    emit finished(id_, error_, data);
+    Q_EMIT finished(id_, error_, data);
 }
 
 void O2Requestor::retry() {

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -20,7 +20,7 @@ public:
     explicit O2Requestor(QNetworkAccessManager *manager, O2 *authenticator, QObject *parent = 0);
     ~O2Requestor();
 
-public slots:
+public Q_SLOTS:
     /// Make a GET request.
     /// @return Request ID or -1 if there are too many requests in the queue.
     int get(const QNetworkRequest &req);
@@ -33,14 +33,14 @@ public slots:
     /// @return Request ID or -1 if there are too many requests in the queue.
     int put(const QNetworkRequest &req, const QByteArray &data);
 
-signals:
+Q_SIGNALS:
     /// Emitted when a request has been completed or failed.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data);
 
     /// Emitted when an upload has progressed.
     void uploadProgress(int id, qint64 bytesSent, qint64 bytesTotal);
 
-protected slots:
+protected Q_SLOTS:
     /// Handle refresh completion.
     void onRefreshFinished(QNetworkReply::NetworkError error);
 
@@ -53,7 +53,7 @@ protected slots:
     /// Re-try request (after successful token refresh).
     void retry();
 
-    /// Finish the request, emit finished() signal.
+    /// Finish the request, Q_EMIT finished() signal.
     void finish();
 
     /// Handle upload progress.

--- a/src/o2skydrive.cpp
+++ b/src/o2skydrive.cpp
@@ -48,13 +48,13 @@ void O2Skydrive::link() {
     query.setQueryItems(parameters);
     url.setQuery(query);
 #endif
-    emit openBrowser(url);
+    Q_EMIT openBrowser(url);
 }
 
 void O2Skydrive::redirected(const QUrl &url) {
     qDebug() << "O2Skydrive::redirected" << url;
 
-    emit closeBrowser();
+    Q_EMIT closeBrowser();
 
     if (grantFlow_ == GrantFlowAuthorizationCode) {
         // Get access code
@@ -67,7 +67,7 @@ void O2Skydrive::redirected(const QUrl &url) {
 #endif
         if (urlCode.isEmpty()) {
             qDebug() << "O2Skydrive::redirected: Code not received";
-            emit linkingFailed();
+            Q_EMIT linkingFailed();
             return;
         }
         setCode(urlCode);
@@ -116,10 +116,10 @@ void O2Skydrive::redirected(const QUrl &url) {
         setRefreshToken(urlRefreshToken);
         setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + urlExpiresIn);
         if (urlToken.isEmpty()) {
-            emit linkingFailed();
+            Q_EMIT linkingFailed();
         } else {
             setLinked(true);
-            emit linkingSucceeded();
+            Q_EMIT linkingSucceeded();
         }
     }
 }

--- a/src/o2skydrive.h
+++ b/src/o2skydrive.h
@@ -10,7 +10,7 @@ class O2Skydrive: public O2 {
 public:
     explicit O2Skydrive(QObject *parent = 0);
 
-public slots:
+public Q_SLOTS:
     Q_INVOKABLE void link();
     Q_INVOKABLE virtual void redirected(const QUrl &url);
 };

--- a/src/oxtwitter.cpp
+++ b/src/oxtwitter.cpp
@@ -18,7 +18,7 @@ QString OXTwitter::username() {
 
 void OXTwitter::setUsername(const QString &username) {
     username_ = username;
-    emit usernameChanged();
+    Q_EMIT usernameChanged();
 }
 
 QString OXTwitter::password() {
@@ -27,7 +27,7 @@ QString OXTwitter::password() {
 
 void OXTwitter::setPassword(const QString &password) {
     password_ = password;
-    emit passwordChanged();
+    Q_EMIT passwordChanged();
 }
 
 void OXTwitter::link() {

--- a/src/oxtwitter.h
+++ b/src/oxtwitter.h
@@ -20,11 +20,11 @@ public:
     QString password();
     void setPassword(const QString &password);
 
-public slots:
+public Q_SLOTS:
     /// Authenticate.
     Q_INVOKABLE virtual void link();
 
-signals:
+Q_SIGNALS:
     void usernameChanged();
     void passwordChanged();
 


### PR DESCRIPTION
Many projects build without Qt keywords enabled, so signals and slots are syntactically invalid. Also fix a compile error and warnings about a superfluous semicolon.