### PR TITLE
Support imgur authorization

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -167,8 +167,12 @@ void O2::link() {
         parameters.append(qMakePair(QString(O2_OAUTH2_RESPONSE_TYPE), (grantFlow_ == GrantFlowAuthorizationCode)? QString(O2_OAUTH2_GRANT_TYPE_CODE): QString(O2_OAUTH2_GRANT_TYPE_TOKEN)));
         parameters.append(qMakePair(QString(O2_OAUTH2_CLIENT_ID), clientId_));
         parameters.append(qMakePair(QString(O2_OAUTH2_REDIRECT_URI), redirectUri_));
-        parameters.append(qMakePair(QString(O2_OAUTH2_SCOPE), scope_));
-        parameters.append(qMakePair(QString(O2_OAUTH2_API_KEY), apiKey_));
+
+        // Some services show an error if those are empty
+        if(!scope_.isEmpty())
+            parameters.append(qMakePair(QString(O2_OAUTH2_SCOPE), scope_));
+        if(!apiKey().isEmpty())
+            parameters.append(qMakePair(QString(O2_OAUTH2_API_KEY), apiKey_));
 
         // Show authentication URL with a web browser
         QUrl url(requestUrl_);


### PR DESCRIPTION
- The imgur API does not like empty paramters

I really don't know why it is required, but without this imgur returns a 500 status and says it's under heavy load...