### PR TITLE
Add o2.pri

### DIFF
--- a/src/o2.pri
+++ b/src/o2.pri
@@ -1,0 +1,1 @@
+include(src.pri)


### PR DESCRIPTION
It is more suitable to see 'o2' section in QtCreator instead 'src' section when a user adds .pri file to his project. It also maintains backwards compatibility with code that includes src.pri