### PR TITLE
Add spotify oauth classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(o2_WITH_FACEBOOK "Authenticate with Facebook" OFF)
 option(o2_WITH_SKYDRIVE "Authenticate with SkyDrive" OFF)
 option(o2_WITH_FLICKR "Authenticate with Flickr" OFF)
 option(o2_WITH_HUBIC "Authenticate with Hubic" OFF)
+option(o2_WITH_SPOTIFY "Authenticate with Spotify" OFF)
 
 option(o2_WITH_OAUTH1 "Include OAuth1 authentication" OFF)
 if(o2_WITH_TWITTER OR o2_WITH_DROPBOX OR o2_WITH_FLICKR)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,3 +7,7 @@ endif(o2_WITH_FACEBOOK)
 if(o2_WITH_TWITTER)
     add_subdirectory(twitterdemo)
 endif(o2_WITH_TWITTER)
+
+if(o2_WITH_SPOTIFY)
+    add_subdirectory(spotifydemo)
+endif(o2_WITH_SPOTIFY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,13 @@ if(o2_WITH_HUBIC)
     )
 endif(o2_WITH_HUBIC)
 
+if(o2_WITH_SPOTIFY)
+    set( o2_SRCS
+        ${o2_SRCS}
+        o2spotify.cpp
+    )
+endif(o2_WITH_SPOTIFY)
+
 if(NOT o2_WITH_QT5)
     add_definitions(${QT4_DEFINITIONS})
 endif(NOT o2_WITH_QT5)

--- a/src/o2spotify.cpp
+++ b/src/o2spotify.cpp
@@ -1,0 +1,9 @@
+#include "o2spotify.h"
+
+static const char *SpotifyEndpoint = "https://accounts.spotify.com/authorize";
+static const char *SpotifyTokenUrl = "https://accounts.spotify.com/api/token";
+
+O2Spotify::O2Spotify(QObject *parent): O2(parent) {
+    setRequestUrl(SpotifyEndpoint);
+    setTokenUrl(SpotifyTokenUrl);
+}

--- a/src/o2spotify.h
+++ b/src/o2spotify.h
@@ -1,0 +1,14 @@
+#ifndef O2SPOTIFY_H
+#define O2SPOTIFY_H
+
+#include "o2.h"
+
+/// Spotify's dialect of OAuth 2.0
+class O2Spotify: public O2 {
+    Q_OBJECT
+
+public:
+    explicit O2Spotify(QObject *parent = 0);
+};
+
+#endif // O2SPOTIFY_H


### PR DESCRIPTION
Hi there,
Thanks for building the lib.

Not sure if this is strictly required but I added a spotify subclass.

I also create a spotify example client, which is basically a copy of the FB example client. If you want it as well I can include it in this PR. (see https://github.com/lukedirtwalker/o2/tree/spotifyDemo)

Cheers