### PR TITLE
Define and use DLL export/import declarations when building under Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ endif()
 
 option(o2_BUILD_EXAMPLES "Build examples" OFF)
 
+if(WIN32)
+  add_definitions(-DO2_DLL_EXPORT)
+endif()
+
 add_subdirectory(src)
 
 if(o2_BUILD_EXAMPLES)

--- a/src/o0abstractstore.h
+++ b/src/o0abstractstore.h
@@ -4,8 +4,10 @@
 #include <QObject>
 #include <QString>
 
+#include "o0export.h"
+
 /// Storage for strings.
-class O0AbstractStore: public QObject {
+class O0_EXPORT O0AbstractStore: public QObject {
     Q_OBJECT
 
 public:

--- a/src/o0baseauth.h
+++ b/src/o0baseauth.h
@@ -8,11 +8,12 @@
 #include <QUrl>
 #include <QVariantMap>
 
+#include "o0export.h"
 #include "o0abstractstore.h"
 #include "o0requestparameter.h"
 
 /// Base class of OAuth authenticators
-class O0BaseAuth : public QObject {
+class O0_EXPORT O0BaseAuth : public QObject {
     Q_OBJECT
 
 public:

--- a/src/o0export.h
+++ b/src/o0export.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// For exporting symbols from Windows' DLLs
+#ifdef _WIN32
+    #ifdef O2_DLL_EXPORT
+        #define O0_EXPORT __declspec(dllexport)
+    #else
+        #define O0_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define O0_EXPORT
+#endif

--- a/src/o0requestparameter.h
+++ b/src/o0requestparameter.h
@@ -1,8 +1,10 @@
 #ifndef O0REQUESTPARAMETER_H
 #define O0REQUESTPARAMETER_H
 
+#include "o0baseauth.h"
+
 /// Request parameter (name-value pair) participating in authentication.
-struct O0RequestParameter {
+struct O0_EXPORT O0RequestParameter {
     O0RequestParameter(const QByteArray &n, const QByteArray &v): name(n), value(v) {}
     bool operator <(const O0RequestParameter &other) const {
         return (name == other.name)? (value < other.value): (name < other.name);

--- a/src/o0settingsstore.h
+++ b/src/o0settingsstore.h
@@ -4,11 +4,12 @@
 #include <QSettings>
 #include <QString>
 
+#include "o0baseauth.h"
 #include "o0abstractstore.h"
 #include "o0simplecrypt.h"
 
 /// Persistent storage for authentication tokens, using QSettings.
-class O0SettingsStore: public O0AbstractStore {
+class O0_EXPORT O0SettingsStore: public O0AbstractStore {
     Q_OBJECT
 
 public:

--- a/src/o0simplecrypt.h
+++ b/src/o0simplecrypt.h
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QVector>
 #include <QFlags>
 
+#include "o0baseauth.h"
+
 /**
   @short Simple encryption and decryption of strings and byte arrays
 
@@ -54,7 +56,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   SimpleCrypt is prepared for the case that the encryption and decryption
   algorithm is changed in a later version, by prepending a version identifier to the cypertext.
   */
-class O0SimpleCrypt
+class O0_EXPORT O0SimpleCrypt
 {
 public:
     /**

--- a/src/o1.h
+++ b/src/o1.h
@@ -5,12 +5,13 @@
 #include <QUrl>
 #include <QNetworkReply>
 
+#include "o0export.h"
 #include "o0baseauth.h"
 
 class O2ReplyServer;
 
 /// Simple OAuth 1.0 authenticator.
-class O1: public O0BaseAuth {
+class O0_EXPORT O1: public O0BaseAuth {
     Q_OBJECT
 
 public:

--- a/src/o1dropbox.h
+++ b/src/o1dropbox.h
@@ -1,10 +1,11 @@
 #ifndef O1DROPBOX_H
 #define O1DROPBOX_H
 
+#include "o0export.h"
 #include "o1.h"
 
 /// Dropbox authenticator
-class O1Dropbox: public O1 {
+class O0_EXPORT O1Dropbox: public O1 {
     Q_OBJECT
 
 public:

--- a/src/o1flickr.h
+++ b/src/o1flickr.h
@@ -1,10 +1,11 @@
 #ifndef O1FLICKR_H
 #define O1FLICKR_H
 
+#include "o0export.h"
 #include "o1.h"
 
 /// Flickr authenticator.
-class O1Flickr: public O1 {
+class O0_EXPORT O1Flickr: public O1 {
     Q_OBJECT
 
 public:

--- a/src/o1freshbooks.h
+++ b/src/o1freshbooks.h
@@ -1,10 +1,11 @@
 #ifndef O1FRESHBOOKS_H
 #define O1FRESHBOOKS_H
 
+#include "o0export.h"
 #include "o1.h"
 
 /// FreshBooks authenticator.
-class O1Freshbooks: public O1 {
+class O0_EXPORT O1Freshbooks: public O1 {
     Q_OBJECT
 
 public:

--- a/src/o1requestor.h
+++ b/src/o1requestor.h
@@ -5,6 +5,7 @@
 #include <QNetworkRequest>
 #include <QByteArray>
 
+#include "o0export.h"
 #include "o1.h"
 
 class QNetworkAccessManager;
@@ -12,7 +13,7 @@ class QNetworkReply;
 class O1;
 
 /// Makes authenticated requests using OAuth 1.0.
-class O1Requestor: public QObject {
+class O0_EXPORT O1Requestor: public QObject {
     Q_OBJECT
 
 public:

--- a/src/o1timedreply.h
+++ b/src/o1timedreply.h
@@ -4,8 +4,10 @@
 #include <QNetworkReply>
 #include <QTimer>
 
+#include "o0export.h"
+
 /// A timer connected to a network reply.
-class O1TimedReply: public QTimer {
+class O0_EXPORT O1TimedReply: public QTimer {
     Q_OBJECT
 
 public:

--- a/src/o1twitter.h
+++ b/src/o1twitter.h
@@ -1,10 +1,11 @@
 #ifndef O1TWITTER_H
 #define O1TWITTER_H
 
+#include "o0export.h"
 #include "o1.h"
 
 /// Twitter OAuth 1.0 client
-class O1Twitter: public O1 {
+class O0_EXPORT O1Twitter: public O1 {
     Q_OBJECT
 
 public:

--- a/src/o2.h
+++ b/src/o2.h
@@ -6,6 +6,7 @@
 #include <QNetworkReply>
 #include <QPair>
 
+#include "o0export.h"
 #include "o0baseauth.h"
 #include "o2reply.h"
 #include "o0abstractstore.h"
@@ -13,7 +14,7 @@
 class O2ReplyServer;
 
 /// Simple OAuth2 authenticator.
-class O2: public O0BaseAuth {
+class O0_EXPORT O2: public O0BaseAuth {
     Q_OBJECT
     Q_ENUMS(GrantFlow)
 

--- a/src/o2facebook.h
+++ b/src/o2facebook.h
@@ -1,10 +1,11 @@
 #ifndef O2FACEBOOK_H
 #define O2FACEBOOK_H
 
+#include "o0export.h"
 #include "o2.h"
 
 /// Facebook's dialect of OAuth 2.0
-class O2Facebook: public O2 {
+class O0_EXPORT O2Facebook: public O2 {
     Q_OBJECT
 
 public:

--- a/src/o2gft.h
+++ b/src/o2gft.h
@@ -1,10 +1,11 @@
 #ifndef O2GFT_H
 #define O2GFT_H
 
+#include "o0export.h"
 #include "o2.h"
 
 /// Google Fusion Tables' dialect of OAuth 2.0
-class O2Gft: public O2 {
+class O0_EXPORT O2Gft: public O2 {
     Q_OBJECT
 
 public:

--- a/src/o2hubic.h
+++ b/src/o2hubic.h
@@ -1,10 +1,11 @@
 #ifndef O2HUBIC_H
 #define O2HUBIC_H
 
+#include "o0export.h"
 #include "o2.h"
 
 /// Hubic's dialect of OAuth 2.0
-class O2Hubic: public O2 {
+class O0_EXPORT O2Hubic: public O2 {
     Q_OBJECT
 
 public:

--- a/src/o2reply.h
+++ b/src/o2reply.h
@@ -8,8 +8,10 @@
 #include <QNetworkAccessManager>
 #include <QByteArray>
 
+#include "o0export.h"
+
 /// A network request/reply pair that can time out.
-class O2Reply: public QTimer {
+class O0_EXPORT O2Reply: public QTimer {
     Q_OBJECT
 
 public:

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -6,8 +6,10 @@
 #include <QByteArray>
 #include <QString>
 
+#include "o0export.h"
+
 /// HTTP server to process authentication response.
-class O2ReplyServer: public QTcpServer {
+class O0_EXPORT O2ReplyServer: public QTcpServer {
     Q_OBJECT
 
 public:

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -8,12 +8,13 @@
 #include <QUrl>
 #include <QByteArray>
 
+#include "o0export.h"
 #include "o2reply.h"
 
 class O2;
 
 /// Makes authenticated requests.
-class O2Requestor: public QObject {
+class O0_EXPORT O2Requestor: public QObject {
     Q_OBJECT
 
 public:

--- a/src/o2skydrive.h
+++ b/src/o2skydrive.h
@@ -1,10 +1,11 @@
 #ifndef O2SKYDRIVE_H
 #define O2SKYDRIVE_H
 
+#include "o0export.h"
 #include "o2.h"
 
 /// Skydrive's dialect of OAuth 2.0
-class O2Skydrive: public O2 {
+class O0_EXPORT O2Skydrive: public O2 {
     Q_OBJECT
 
 public:

--- a/src/o2surveymonkey.h
+++ b/src/o2surveymonkey.h
@@ -1,10 +1,11 @@
 #ifndef O2SURVEYMONKEY_H
 #define O2SURVEYMONKEY_H
 
+#include "o0export.h"
 #include "o2.h"
 
 /// SurveyMonkey's dialect of OAuth 2.0
-class O2SurveyMonkey: public O2 {
+class O0_EXPORT O2SurveyMonkey: public O2 {
     Q_OBJECT
 
 public:

--- a/src/oxtwitter.h
+++ b/src/oxtwitter.h
@@ -1,10 +1,11 @@
 #ifndef OXTWITTER_H
 #define OXTWITTER_H
 
+#include "o0export.h"
 #include "o1twitter.h"
 
 /// Twitter authenticator using Twitter XAuth
-class OXTwitter: public O1Twitter {
+class O0_EXPORT OXTwitter: public O1Twitter {
     Q_OBJECT
 
 public:


### PR DESCRIPTION
Credits due to @dbrnz since this is effectively a copy/paste of his work (see https://github.com/dbrnz/o2/commit/d3f1a01e372bab9dc2666de71357373c8c1bf661).