### PR TITLE
Add pkg-config file

### DIFF
--- a/o2.pc.cmake
+++ b/o2.pc.cmake
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/lib@o2_LIB_SUFFIX@
+includedir=${prefix}/include/o2
+
+Name: o2
+Description: OAuth 2.0 for Qt
+Version: @PROJECT_VERSION@
+
+Cflags: -I${includedir} @CMAKE_INCLUDE_PATH@
+Libs: -L${libdir} @CMAKE_LIBRARY_PATH@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,3 +190,7 @@ install(TARGETS o2
 install(FILES ${o2_HDRS}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/o2
 )
+
+message(STATUS "Writing pkg-config file...")
+configure_file(${CMAKE_SOURCE_DIR}/o2.pc.cmake ${CMAKE_BINARY_DIR}/o2.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/o2.pc DESTINATION "${CMAKE_INSTALL_PREFIX}/lib${o2_LIB_SUFFIX}/pkgconfig/")


### PR DESCRIPTION
Why?
> Without a metadata system such as pkg-config, it can be very difficult to locate and obtain details about the services provided on a given computer. For a developer, installing pkg-config files with your package greatly eases adoption of your API.