### PR TITLE
removed default scope for google oauth

### DIFF
--- a/src/o2gft.cpp
+++ b/src/o2gft.cpp
@@ -1,6 +1,5 @@
 #include "o2gft.h"
 
-static const char *GftScope = "https://www.googleapis.com/auth/fusiontables";
 static const char *GftEndpoint = "https://accounts.google.com/o/oauth2/auth";
 static const char *GftTokenUrl = "https://accounts.google.com/o/oauth2/token";
 static const char *GftRefreshUrl = "https://accounts.google.com/o/oauth2/token";
@@ -9,5 +8,4 @@ O2Gft::O2Gft(QObject *parent): O2(parent) {
     setRequestUrl(GftEndpoint);
     setTokenUrl(GftTokenUrl);
     setRefreshTokenUrl(GftRefreshUrl);
-    setScope(GftScope);
 }


### PR DESCRIPTION
Not sure why this scope is set by default. google has a large list of possible scopes. 

https://developers.google.com/identity/protocols/googlescopes