### PR TITLE
added keychain store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8.11)
 if(POLICY CMP0048) # in CMake >= 3.0.0
     cmake_policy(SET CMP0048 OLD) # keep project() from clearing VERSION variables
 endif(POLICY CMP0048)
+
+set( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules )
+
 set(VER_MAJOR "1")
 set(VER_MINOR "0")
 set(VER_PATCH "1")
@@ -33,6 +36,7 @@ option(o2_WITH_FLICKR "Authenticate with Flickr" OFF)
 option(o2_WITH_HUBIC "Authenticate with Hubic" OFF)
 option(o2_WITH_SPOTIFY "Authenticate with Spotify" OFF)
 option(o2_WITH_SURVEYMONKEY "Authenticate with SurveyMonkey" OFF)
+option(o2_WITH_KEYCHAIN "keychain store" ON)
 
 option(o2_WITH_OAUTH1 "Include OAuth1 authentication" OFF)
 if(o2_WITH_TWITTER OR o2_WITH_DROPBOX OR o2_WITH_FLICKR)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Class | Header | Purpose
 :-- | :-- | :--
 O0AbstractStore | o0abstractstore.h | Base class of persistent stores
 O0BaseAuth | o0baseauth.h | Base class of OAuth authenticators
-O0SettingsStore | o0simplecrypt.h | QSettings-based persistent store
+O0SettingsStore | o0settingsstore.h | QSettings-based persistent store
 o0keyChainStore | o0keychainstore.h | Settings stored through the system keychain [keychain](https://github.com/frankosterfeld/qtkeychain)
 O0SimpleCrypt | o0simplecrypt.h | Simple encryption and decryption by Andre Somers
 O1 | o1.h | Generic OAuth 1.0 authenticator
@@ -28,7 +28,7 @@ O1Twitter | o1twitter.h | Twitter OAuth specialization
 O2 | o2.h | Generic OAuth 2.0 authenticator
 O2Facebook | o2facebook.h | Facebook OAuth specialization
 O2Gft | o2gft.h | Google Fusion Tables OAuth specialization
-O2Google | o2gft.h | Google Oauth specialization [scopes](https://developers.google.com/identity/protocols/googlescopes)
+O2Google | o2google.h | Google Oauth specialization [scopes](https://developers.google.com/identity/protocols/googlescopes)
 O2Hubic | o2hubic.h | Hubic OAuth specialization
 O2Reply | o2reply.h | A network request/reply that can time out
 O2ReplyServer | o2replyserver.h | HTTP server to process authentication responses

--- a/cmake/modules/FindQt5Keychain.cmake
+++ b/cmake/modules/FindQt5Keychain.cmake
@@ -1,0 +1,38 @@
+# (c) 2014 Copyright ownCloud GmbH
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING* file.
+
+# - Try to find QtKeychain
+# Once done this will define
+#  QTKEYCHAIN_FOUND - System has QtKeychain
+#  QTKEYCHAIN_INCLUDE_DIRS - The QtKeychain include directories
+#  QTKEYCHAIN_LIBRARIES - The libraries needed to use QtKeychain
+#  QTKEYCHAIN_DEFINITIONS - Compiler switches required for using LibXml2
+
+find_path(QTKEYCHAIN_INCLUDE_DIR
+        NAMES
+        keychain.h
+        PATH_SUFFIXES
+        qt5keychain
+        )
+
+find_library(QTKEYCHAIN_LIBRARY
+        NAMES
+        qt5keychain
+        lib5qtkeychain
+        PATHS
+        /usr/lib
+        /usr/lib/${CMAKE_ARCH_TRIPLET}
+        /usr/local/lib
+        /opt/local/lib
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+        )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set QTKEYCHAIN_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Qt5Keychain  DEFAULT_MSG
+        QTKEYCHAIN_LIBRARY QTKEYCHAIN_INCLUDE_DIR)
+
+mark_as_advanced(QTKEYCHAIN_INCLUDE_DIR QTKEYCHAIN_LIBRARY)

--- a/cmake/modules/FindQtKeychain.cmake
+++ b/cmake/modules/FindQtKeychain.cmake
@@ -1,0 +1,39 @@
+# (c) 2014 Copyright ownCloud GmbH
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING* file.
+
+# - Try to find QtKeychain
+# Once done this will define
+#  QTKEYCHAIN_FOUND - System has QtKeychain
+#  QTKEYCHAIN_INCLUDE_DIRS - The QtKeychain include directories
+#  QTKEYCHAIN_LIBRARIES - The libraries needed to use QtKeychain
+#  QTKEYCHAIN_DEFINITIONS - Compiler switches required for using LibXml2
+
+find_path(QTKEYCHAIN_INCLUDE_DIR
+        NAMES
+        keychain.h
+        PATH_SUFFIXES
+        qtkeychain
+        )
+
+
+find_library(QTKEYCHAIN_LIBRARY
+        NAMES
+        qtkeychain
+        libqtkeychain
+        PATHS
+        /usr/lib
+        /usr/lib/${CMAKE_ARCH_TRIPLET}
+        /usr/local/lib
+        /opt/local/lib
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+        )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set QTKEYCHAIN_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(QtKeychain  DEFAULT_MSG
+        QTKEYCHAIN_LIBRARY QTKEYCHAIN_INCLUDE_DIR)
+
+mark_as_advanced(QTKEYCHAIN_INCLUDE_DIR QTKEYCHAIN_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ if (NOT o2_WITH_QT5)
     include( ${QT_USE_FILE} )
 endif(NOT o2_WITH_QT5)
 
+
 set( o2_SRCS
     o2.cpp
     o2reply.cpp
@@ -79,11 +80,11 @@ if(o2_WITH_GOOGLE)
     set( o2_SRCS
         ${o2_SRCS}
         o2gft.cpp
-    )
+            )
     set( o2_HDRS
         ${o2_HDRS}
         o2gft.h
-    )
+            )
 endif(o2_WITH_GOOGLE)
 
 if(o2_WITH_FACEBOOK)
@@ -148,6 +149,35 @@ if(o2_WITH_SURVEYMONKEY)
     )
 endif(o2_WITH_SURVEYMONKEY)
 
+
+if(o2_WITH_KEYCHAIN)
+    if (Qt5Core_DIR)
+        find_package(Qt5Keychain REQUIRED)
+    else()
+        find_package(QtKeychain REQUIRED)
+    endif()
+    if(QTKEYCHAIN_FOUND OR QT5KEYCHAIN_FOUND)
+        MESSAGE("Found QTKeychain")
+        list(APPEND LINK_TARGETS ${QTKEYCHAIN_LIBRARY})
+        include_directories(${QTKEYCHAIN_INCLUDE_DIR})
+        set( o2_SRCS
+                ${o2_SRCS}
+                o0keychainstore.cpp
+                )
+        set( o2_HDRS
+                ${o2_HDRS}
+                o0keychainstore.h
+                )
+    else()
+        MESSAGE("Qt5Keychain or QtKeychain is required")
+    endif()
+
+
+endif(o2_WITH_KEYCHAIN)
+
+
+
+
 if(NOT o2_WITH_QT5)
     add_definitions(${QT4_DEFINITIONS})
 endif(NOT o2_WITH_QT5)
@@ -160,9 +190,9 @@ endif(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042)
 add_library( o2 ${o2_SRCS} ${o2_HDRS} )
 
 if(o2_WITH_QT5)
-    target_link_libraries( o2 Qt5::Core Qt5::Network)
+    target_link_libraries( o2 Qt5::Core Qt5::Network ${LINK_TARGETS})
 else(o2_WITH_QT5)
-    target_link_libraries( o2 ${QT_LIBRARIES} )
+    target_link_libraries( o2 ${QT_LIBRARIES} ${LINK_TARGETS})
 endif(o2_WITH_QT5)
 
 if(BUILD_SHARED_LIBS)

--- a/src/o0keychainstore.cpp
+++ b/src/o0keychainstore.cpp
@@ -1,0 +1,75 @@
+//
+// Created by michaelpollind on 3/13/17.
+//
+#include "o0keychainstore.h"
+
+#include <QDebug>
+#include <keychain.h>
+#include <QtCore/QDataStream>
+#include <QtCore/QBuffer>
+#include <QtCore/QEventLoop>
+
+using namespace QKeychain;
+
+o0keyChainStore::o0keyChainStore(const QString& app,const QString& name,QObject *parent):
+    O0AbstractStore(parent), app_(app),name_(name),pairs_()
+{
+}
+
+QString o0keyChainStore::value(const QString &key, const QString &defaultValue) {
+    return  pairs_.value(key);
+}
+
+void o0keyChainStore::setValue(const QString &key, const QString &value) {
+    pairs_.insert(key,value);
+}
+
+void o0keyChainStore::persist() {
+    WritePasswordJob job(app_);
+    job.setAutoDelete(false);
+    job.setKey(name_);
+    QByteArray data;
+    QDataStream ds(&data,QIODevice::ReadWrite);
+    ds << pairs_;
+
+    job.setTextData(data);
+    QEventLoop loop;
+    job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+    job.start();
+    loop.exec();
+    if(job.error())
+    {
+        qWarning() << "keychain could not be persisted "<< name_ << ":" << qPrintable(job.errorString());
+    }
+}
+
+void o0keyChainStore::fetchFromKeychain() {
+    ReadPasswordJob job(app_);
+    job.setKey(name_);
+    QEventLoop loop;
+    job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+    job.start();
+    loop.exec();
+
+    QByteArray data;
+    data.append(job.textData());
+    QDataStream ds(&data,QIODevice::ReadOnly);
+    ds >> pairs_;
+
+    if(job.error())
+    {
+        qWarning() << "keychain could not be fetched"<< name_ << ":" << qPrintable(job.errorString());
+    }
+}
+
+void o0keyChainStore::clearFromKeychain() {
+    DeletePasswordJob job(app_);
+    job.setKey(name_);
+    QEventLoop loop;
+    job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+    job.start();
+    loop.exec();
+    if ( job.error() ) {
+        qWarning() << "Deleting keychain failed: " << qPrintable(job.errorString());
+    }
+}

--- a/src/o0keychainstore.h
+++ b/src/o0keychainstore.h
@@ -1,0 +1,33 @@
+//
+// Created by michaelpollind on 3/13/17.
+//
+#ifndef O2_O0KEYCHAINSTORE_H
+#define O2_O0KEYCHAINSTORE_H
+
+#include <QtCore/QMap>
+#include "o0abstractstore.h"
+#include <QString>
+
+class o0keyChainStore  : public  O0AbstractStore{
+    Q_OBJECT
+public:
+    explicit o0keyChainStore(const QString& app,const QString& name,QObject *parent = 0);
+
+    /// Retrieve a string value by key.
+    virtual QString value(const QString &key, const QString &defaultValue = QString()) = 0;
+
+    /// Set a string value for a key.
+    virtual void setValue(const QString &key, const QString &value) = 0;
+
+    void persist();
+    void fetchFromKeychain();
+    void clearFromKeychain();
+private:
+    QString app_;
+    QString name_;
+    QMap<QString,QString> pairs_;
+
+};
+
+
+#endif //O2_O0KEYCHAINSTORE_H


### PR DESCRIPTION
This pull request implements qtkeychain. I think this would generally be preferable over encryption through obfuscation. You will have to test this on your end to make sure this works. I will probably test if this works on my own end but I would like to make this available for review.

https://github.com/frankosterfeld/qtkeychain
> 
> - Mac OS X: Passwords are stored in the OS X Keychain.
> 
> - Linux/Unix: If running, GNOME Keyring is used, otherwise qtkeychain tries to use KWallet (via D-Bus), if available.
> 
> - Windows: By default, the Windows Credential Store is used (requires Windows 7 or newer). Pass -DUSE_CREDENTIAL_STORE=OFF to cmake use disable it. If disabled, QtKeychain uses the Windows API function CryptProtectData to encrypt the password with the user's logon credentials. The encrypted data is then persisted via QSettings.
> 
