### PR TITLE
O2 Monsanto Company features

### DIFF
--- a/examples/implicit_redirect.html
+++ b/examples/implicit_redirect.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+// Push any fragment as a query string to redirect server
+// Allows for an implicit flow's returned #token to be seen by o2 as ?token
+window.onload = function hashFunction() {
+    var query = location.hash.substr(1)
+    if (query != "") {
+        var xhttp = new XMLHttpRequest();
+        xhttp.open("GET", "/?" + query, true);
+        xhttp.send();
+    }
+}
+</script>
+</head>
+<body>
+
+<h2>OAuth2 verification has finished</h2>
+
+<h3>If you have not been returned to your application, bring it to the forefront.</h3>
+
+<p><a href="#" onclick="window.close()">Close window</a></p>
+
+</body>
+</html>

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -20,9 +20,9 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 
-O1::O1(QObject *parent): O0BaseAuth(parent) {
+O1::O1(QObject *parent, QNetworkAccessManager *manager): O0BaseAuth(parent) {
     setSignatureMethod(O2_SIGNATURE_TYPE_HMAC_SHA1);
-    manager_ = new QNetworkAccessManager(this);
+    manager_ = manager ? manager : new QNetworkAccessManager(this);
     replyServer_ = new O2ReplyServer(this);
     qRegisterMetaType<QNetworkReply::NetworkError>("QNetworkReply::NetworkError");
     connect(replyServer_, SIGNAL(verificationReceived(QMap<QString,QString>)), this, SLOT(onVerificationReceived(QMap<QString,QString>)));

--- a/src/o1.h
+++ b/src/o1.h
@@ -48,7 +48,7 @@ public:
     void setAccessTokenUrl(const QUrl &value);
 
     /// Constructor.
-    explicit O1(QObject *parent = 0);
+    explicit O1(QObject *parent = 0, QNetworkAccessManager *manager = 0);
 
     /// Parse a URL-encoded response string.
     static QMap<QString, QString> parseResponse(const QByteArray &response);

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -67,8 +67,8 @@ static void addQueryParametersToUrl(QUrl &url,  QList<QPair<QString, QString> > 
 #endif
 }
 
-O2::O2(QObject *parent): O0BaseAuth(parent) {
-    manager_ = new QNetworkAccessManager(this);
+O2::O2(QObject *parent, QNetworkAccessManager *manager): O0BaseAuth(parent) {
+    manager_ = manager ? manager : new QNetworkAccessManager(this);
     replyServer_ = new O2ReplyServer(this);
     grantFlow_ = GrantFlowAuthorizationCode;
     localhostPolicy_ = QString(O2_CALLBACK_URL);

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -121,6 +121,17 @@ void O2::setRequestUrl(const QString &value) {
     Q_EMIT requestUrlChanged();
 }
 
+QVariantMap O2::extraRequestParams()
+{
+  return extraReqParams_;
+}
+
+void O2::setExtraRequestParams(const QVariantMap &value)
+{
+  extraReqParams_ = value;
+  Q_EMIT extraRequestParamsChanged();
+}
+
 QString O2::tokenUrl() {
     return tokenUrl_.toString();
 }
@@ -165,13 +176,16 @@ void O2::link() {
 
         // Assemble intial authentication URL
         QList<QPair<QString, QString> > parameters;
-        parameters.append(qMakePair(QString(O2_OAUTH2_RESPONSE_TYPE), (grantFlow_ == GrantFlowAuthorizationCode)? QString(O2_OAUTH2_GRANT_TYPE_CODE): QString(O2_OAUTH2_GRANT_TYPE_TOKEN)));
+        parameters.append(qMakePair(QString(O2_OAUTH2_RESPONSE_TYPE),
+                                    (grantFlow_ == GrantFlowAuthorizationCode)? QString(O2_OAUTH2_GRANT_TYPE_CODE): QString(O2_OAUTH2_GRANT_TYPE_TOKEN)));
         parameters.append(qMakePair(QString(O2_OAUTH2_CLIENT_ID), clientId_));
         parameters.append(qMakePair(QString(O2_OAUTH2_REDIRECT_URI), redirectUri_));
         parameters.append(qMakePair(QString(O2_OAUTH2_SCOPE), scope_.replace( " ", "+" )));
         if ( !apiKey_.isEmpty() )
             parameters.append(qMakePair(QString(O2_OAUTH2_API_KEY), apiKey_));
-
+        foreach (QString key, extraRequestParams().keys()) {
+            parameters.append(qMakePair(key, extraRequestParams().value(key).toString()));
+        }
         // Show authentication URL with a web browser
         QUrl url(requestUrl_);
         addQueryParametersToUrl(url, parameters);
@@ -188,6 +202,9 @@ void O2::link() {
         parameters.append(O0RequestParameter(O2_OAUTH2_SCOPE, scope_.toUtf8()));
         if ( !apiKey_.isEmpty() )
             parameters.append(O0RequestParameter(O2_OAUTH2_API_KEY, apiKey_.toUtf8()));
+        foreach (QString key, extraRequestParams().keys()) {
+            parameters.append(O0RequestParameter(key.toUtf8(), extraRequestParams().value(key).toByteArray()));
+        }
         QByteArray payload = O0BaseAuth::createQueryParameters(parameters);
 
         QUrl url(tokenUrl_);

--- a/src/o2.h
+++ b/src/o2.h
@@ -76,6 +76,11 @@ public:
     QString requestUrl();
     void setRequestUrl(const QString &value);
 
+    /// User-defined extra parameters to append to request URL
+    Q_PROPERTY(QVariantMap extraRequestParams READ extraRequestParams WRITE setExtraRequestParams NOTIFY extraRequestParamsChanged)
+    QVariantMap extraRequestParams();
+    void setExtraRequestParams(const QVariantMap &value);
+
     /// Token request URL.
     Q_PROPERTY(QString tokenUrl READ tokenUrl WRITE setTokenUrl NOTIFY tokenUrlChanged)
     QString tokenUrl();
@@ -120,6 +125,7 @@ Q_SIGNALS:
     void usernameChanged();
     void passwordChanged();
     void requestUrlChanged();
+    void extraRequestParamsChanged();
     void refreshTokenUrlChanged();
     void tokenUrlChanged();
 
@@ -156,6 +162,7 @@ protected:
     QString username_;
     QString password_;
     QUrl requestUrl_;
+    QVariantMap extraReqParams_;
     QUrl tokenUrl_;
     QUrl refreshTokenUrl_;
     QString scope_;

--- a/src/o2.h
+++ b/src/o2.h
@@ -89,7 +89,7 @@ public:
 public:
     /// Constructor.
     /// @param  parent  Parent object.
-    explicit O2(QObject *parent = 0);
+    explicit O2(QObject *parent = 0, QNetworkAccessManager *manager = 0);
 
     /// Get authentication code.
     QString code();

--- a/src/o2.h
+++ b/src/o2.h
@@ -115,6 +115,9 @@ public Q_SLOTS:
     /// Refresh token.
     Q_INVOKABLE void refresh();
 
+    /// Handle situation where reply server has opted to close its connection
+    void serverHasClosed(bool paramsfound = false);
+
 Q_SIGNALS:
     /// Emitted when a token refresh has been completed or failed.
     void refreshFinished(QNetworkReply::NetworkError error);

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QMap>
 #include <QPair>
+#include <QTimer>
 #include <QStringList>
 #include <QUrl>
 #include <QDebug>
@@ -13,21 +14,41 @@
 
 #include "o2replyserver.h"
 
-O2ReplyServer::O2ReplyServer(QObject *parent): QTcpServer(parent) {
+O2ReplyServer::O2ReplyServer(QObject *parent): QTcpServer(parent),
+  timeout_(15), maxtries_(3), tries_(0) {
+    qDebug() << "O2ReplyServer: Starting";
     connect(this, SIGNAL(newConnection()), this, SLOT(onIncomingConnection()));
     replyContent_ = "<HTML></HTML>";
 }
 
 void O2ReplyServer::onIncomingConnection() {
+    qDebug() << "O2ReplyServer::onIncomingConnection: Receiving...";
     QTcpSocket *socket = nextPendingConnection();
     connect(socket, SIGNAL(readyRead()), this, SLOT(onBytesReady()), Qt::UniqueConnection);
     connect(socket, SIGNAL(disconnected()), socket, SLOT(deleteLater()));
+
+    // Wait for a bit *after* first response, then close server if no useable data has arrived
+    // Helps with implicit flow, where a URL fragment may need processed by local user-agent and
+    // sent as secondary query string callback, or additional requests make it through first,
+    // like for favicons, etc., before such secondary callbacks are fired
+    QTimer *timer = new QTimer(socket);
+    timer->setObjectName("timeoutTimer");
+    connect(timer, SIGNAL(timeout()), this, SLOT(closeServer()));
+    timer->setSingleShot(true);
+    timer->setInterval(timeout() * 1000);
+    connect(socket, SIGNAL(readyRead()), timer, SLOT(start()));
 }
 
 void O2ReplyServer::onBytesReady() {
-    qDebug() << "O2ReplyServer::onBytesReady";
+    if (!isListening()) {
+        // server has been closed, stop processing queued connections
+        return;
+    }
+    qDebug() << "O2ReplyServer::onBytesReady: Processing request";
+    // NOTE: on first call, the timeout timer is started
     QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
     if (!socket) {
+        qWarning() << "O2ReplyServer::onBytesReady: No socket available";
         return;
     }
     QByteArray reply;
@@ -36,16 +57,31 @@ void O2ReplyServer::onBytesReady() {
     reply.append(QString("Content-Length: %1\r\n\r\n").arg(replyContent_.size()).toLatin1());
     reply.append(replyContent_);
     socket->write(reply);
+    qDebug() << "O2ReplyServer::onBytesReady: Sent reply";
 
     QByteArray data = socket->readAll();
     QMap<QString, QString> queryParams = parseQueryParams(&data);
-    socket->disconnectFromHost();
-    close();
+    if (queryParams.isEmpty()) {
+        if (tries_ < maxtries_ ) {
+            qDebug() << "O2ReplyServer::onBytesReady: No query params found, waiting for more callbacks";
+            ++tries_;
+            return;
+        } else {
+            tries_ = 0;
+            qWarning() << "O2ReplyServer::onBytesReady: No query params found, maximum callbacks received";
+            closeServer(socket, false);
+            return;
+        }
+    }
+    qDebug() << "O2ReplyServer::onBytesReady: Query params found, closing server";
+    closeServer(socket, true);
     Q_EMIT verificationReceived(queryParams);
 }
 
 QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
     qDebug() << "O2ReplyServer::parseQueryParams";
+
+    //qDebug() << QString("O2ReplyServer::parseQueryParams data:\n%1").arg(QString(*data));
 
     QString splitGetLine = QString(*data).split("\r\n").first();
     splitGetLine.remove("GET ");
@@ -72,10 +108,61 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
     return queryParams;
 }
 
+void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)
+{
+  if (!isListening()) {
+      return;
+  }
+
+  qDebug() << "O2ReplyServer::closeServer: Initiating";
+  int port = serverPort();
+
+  if (!socket && sender()) {
+      QTimer *timer = qobject_cast<QTimer*>(sender());
+      if (timer) {
+          qWarning() << "O2ReplyServer::closeServer: Closing due to timeout";
+          timer->stop();
+          socket = qobject_cast<QTcpSocket *>(timer->parent());
+          timer->deleteLater();
+      }
+  }
+  if (socket) {
+      QTimer *timer = socket->findChild<QTimer*>("timeoutTimer");
+      if (timer) {
+          qDebug() << "O2ReplyServer::closeServer: Stopping socket's timeout timer";
+          timer->stop();
+      }
+      socket->disconnectFromHost();
+  }
+  close();
+  qDebug() << "O2ReplyServer::closeServer: Closed, no longer listening on port" << port;
+  Q_EMIT serverClosed(hasparameters);
+}
+
 QByteArray O2ReplyServer::replyContent() {
     return replyContent_;
 }
 
 void O2ReplyServer::setReplyContent(const QByteArray &value) {
-    replyContent_ = value;
+  replyContent_ = value;
+}
+
+int O2ReplyServer::timeout()
+{
+  return timeout_;
+}
+
+void O2ReplyServer::setTimeout(int timeout)
+{
+  timeout_ = timeout;
+}
+
+int O2ReplyServer::callbackTries()
+{
+  return maxtries_;
+}
+
+void O2ReplyServer::setCallbackTries(int maxtries)
+{
+  maxtries_ = maxtries;
 }

--- a/src/o2replyserver.h
+++ b/src/o2replyserver.h
@@ -20,16 +20,31 @@ public:
     QByteArray replyContent();
     void setReplyContent(const QByteArray &value);
 
+    /// Seconds to keep listening *after* first response for a callback with token content
+    Q_PROPERTY(int timeout READ timeout WRITE setTimeout)
+    int timeout();
+    void setTimeout(int timeout);
+
+    /// Maximum number of callback tries to accept, in case some don't have token content (favicons, etc.)
+    Q_PROPERTY(int callbackTries READ callbackTries WRITE setCallbackTries)
+    int callbackTries();
+    void setCallbackTries(int maxtries);
+
 Q_SIGNALS:
     void verificationReceived(QMap<QString, QString>);
+    void serverClosed(bool); // whether it has found parameters
 
 public Q_SLOTS:
     void onIncomingConnection();
     void onBytesReady();
     QMap<QString, QString> parseQueryParams(QByteArray *data);
+    void closeServer(QTcpSocket *socket = 0, bool hasparameters = false);
 
 protected:
     QByteArray replyContent_;
+    int timeout_;
+    int maxtries_;
+    int tries_;
 };
 
 #endif // O2REPLYSERVER_H


### PR DESCRIPTION
Adds three features to `o2`:
* **External QNetworkAccessManager support for authenticator** - useful for applications that already have a `QNetworkAccessManager`, or custom subclass of one, and where additional state may exist, e.g. proxy settings or extended authorization support.
* **Add extra request parameters support to O2 authenticator** - useful for passing OAuth2 vendor-specific key/value URL pairs, e.g. custom key names which may be necessary for connections, but non-standard OAuth2 pairs.
* **Add support for implicit grant flow completed by Javascript**
  - When user-agent receives the #query response, use Javascript to forward the URL fragment on to the local redirect server as a query parameter string (example HTML provided).
  - This flow requires a timer that fires `linkingFailed` after a singleshot interval, to ensure the linking connections are completed, regardless of connection result.
  - Adds timeout and maximum callback tries to reply server.
  - Fail link if server received no tokens.

Please let me know if splitting these features up into separate PRs is necessary. While the first two features are pretty straightforward, the third (implicit grant flow enhancements) might need implementation details discussion (works in our testing, though).

Work produced by [Boundless Spatial](https://github.com/boundlessgeo) and sponsored by [Monsanto Company](https://github.com/MonsantoCo), in support of an[ OAuth2 authentication method plugin](https://github.com/MonsantoCo/QGIS/tree/oauth2-plugin/src/auth/oauth2) for the [QGIS project](https://github.com/qgis/QGIS).