### PR TITLE
Fix broken build caused by O2Google

### DIFF
--- a/src/o2gft.cpp
+++ b/src/o2gft.cpp
@@ -1,4 +1,5 @@
 #include "o2gft.h"
+#include "o2google.h"
 
 static const char *GftScope = "https://www.googleapis.com/auth/fusiontables";
 static const char *GftEndpoint = "https://accounts.google.com/o/oauth2/auth";

--- a/src/o2google.h
+++ b/src/o2google.h
@@ -5,6 +5,7 @@
 #ifndef O2_O2GOOGLE_H
 #define O2_O2GOOGLE_H
 
+#include "o2.h"
 
 class O2Google : public O2 {
     Q_OBJECT

--- a/src/src.pri
+++ b/src/src.pri
@@ -20,7 +20,8 @@ SOURCES += \
     $$PWD/o2simplecrypt.cpp \
     $$PWD/o0baseauth.cpp \
     $$PWD/o0settingsstore.cpp \
-    $$PWD/o2spotify.cpp
+    $$PWD/o2spotify.cpp \
+    $$PWD/o2google.cpp
 
 HEADERS += \
     $$PWD/o1.h \
@@ -45,4 +46,5 @@ HEADERS += \
     $$PWD/o0requestparameter.h \
     $$PWD/o0abstractstore.h \
     $$PWD/o0settingsstore.h \
-    $$PWD/o2spotify.h
+    $$PWD/o2spotify.h \
+    $$PWD/o2google.h


### PR DESCRIPTION
If you download the current sources and try to build, you will end up with multiple build errors.
This change:
- add 2 missing include
- add the missing o2google in src.pri