### PR TITLE
Remove unused constants causing warnings

### DIFF
--- a/src/o2gft.cpp
+++ b/src/o2gft.cpp
@@ -2,9 +2,6 @@
 #include "o2google.h"
 
 static const char *GftScope = "https://www.googleapis.com/auth/fusiontables";
-static const char *GftEndpoint = "https://accounts.google.com/o/oauth2/auth";
-static const char *GftTokenUrl = "https://accounts.google.com/o/oauth2/token";
-static const char *GftRefreshUrl = "https://accounts.google.com/o/oauth2/token";
 
 O2Gft::O2Gft(QObject *parent): O2Google(parent) {
     setScope(GftScope);


### PR DESCRIPTION
There are 3 unused constants in o2gft.cpp causing some warnings.