### PR TITLE
qSort is deprecated - use std::sort #87

### DIFF
--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -6,6 +6,7 @@
 #include <QDebug>
 #include <QDataStream>
 #include <QStringList>
+#include <algorithm>
 
 #if QT_VERSION >= 0x050000
 #include <QUrlQuery>

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -141,7 +141,7 @@ QByteArray O1::getRequestBase(const QList<O0RequestParameter> &oauthParams, cons
     // Append a sorted+encoded list of all request parameters to the base string
     QList<O0RequestParameter> headers(oauthParams);
     headers.append(otherParams);
-    qSort(headers);
+    std::sort(headers.begin(), headers.end());
     base.append(encodeHeaders(headers));
 
     return base;
@@ -161,7 +161,7 @@ QByteArray O1::buildAuthorizationHeader(const QList<O0RequestParameter> &oauthPa
     bool first = true;
     QByteArray ret("OAuth ");
     QList<O0RequestParameter> headers(oauthParams);
-    qSort(headers);
+    std::sort(headers.begin(), headers.end());
     foreach (O0RequestParameter h, headers) {
         if (first) {
             first = false;


### PR DESCRIPTION
Replace qSort by std::sort to fix deprecated warnings