### PR TITLE
#88 void O2::setExpires(int v) causes warnings

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -282,7 +282,7 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
             int expiresIn = response.value(O2_OAUTH2_EXPIRES_IN).toInt(&ok);
             if (ok) {
                 qDebug() << "O2::onVerificationReceived: Token expires in" << expiresIn << "seconds";
-                setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn);
+                setExpires((int)(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn));
             }
           }
           setLinked(true);
@@ -340,7 +340,7 @@ void O2::onTokenReplyFinished() {
             int expiresIn = tokens.take(O2_OAUTH2_EXPIRES_IN).toInt(&ok);
             if (ok) {
                 qDebug() << "O2::onTokenReplyFinished: Token expires in" << expiresIn << "seconds";
-                setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn);
+                setExpires((int)(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn));
             }
             setRefreshToken(tokens.take(O2_OAUTH2_REFRESH_TOKEN).toString());
             setExtraTokens(tokens);
@@ -437,7 +437,7 @@ void O2::onRefreshFinished() {
         QByteArray reply = refreshReply->readAll();
         QVariantMap tokens = parseTokenResponse(reply);
         setToken(tokens.value(O2_OAUTH2_ACCESS_TOKEN).toString());
-        setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value(O2_OAUTH2_EXPIRES_IN).toInt());
+        setExpires((int)(QDateTime::currentMSecsSinceEpoch() / 1000 + tokens.value(O2_OAUTH2_EXPIRES_IN).toInt()));
         setRefreshToken(tokens.value(O2_OAUTH2_REFRESH_TOKEN).toString());
         timedReplies_.remove(refreshReply);
         setLinked(true);

--- a/src/o2skydrive.cpp
+++ b/src/o2skydrive.cpp
@@ -114,7 +114,7 @@ void O2Skydrive::redirected(const QUrl &url) {
 
         setToken(urlToken);
         setRefreshToken(urlRefreshToken);
-        setExpires(QDateTime::currentMSecsSinceEpoch() / 1000 + urlExpiresIn);
+        setExpires((int)(QDateTime::currentMSecsSinceEpoch() / 1000 + urlExpiresIn));
         if (urlToken.isEmpty()) {
             Q_EMIT linkingFailed();
         } else {


### PR DESCRIPTION
#88 void O2::setExpires(int v) causes warnings because qint64 passed as parameter

Fix warnings caused by setExpires(int v) because qint64 is passed as parameter