### PR TITLE
Forward replyServer_'s reply content getter/setter in O1

### DIFF
--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -81,6 +81,14 @@ void O1::setAccessTokenUrl(const QUrl &value) {
     Q_EMIT accessTokenUrlChanged();
 }
 
+QByteArray O1::replyContent() const {
+    return replyServer_->replyContent();
+}
+
+void O1::setReplyContent(const QByteArray &value) {
+    replyServer_->setReplyContent(value);
+}
+
 QString O1::signatureMethod() {
     return signatureMethod_;
 }

--- a/src/o1.h
+++ b/src/o1.h
@@ -55,6 +55,12 @@ public:
     QUrl accessTokenUrl();
     void setAccessTokenUrl(const QUrl &value);
 
+    /// Page content on local host after successful oauth.
+    /// Provide it in case you do not want to close the browser, but display something
+    Q_PROPERTY(QByteArray replyContent READ replyContent WRITE setReplyContent)
+    QByteArray replyContent() const;
+    void setReplyContent(const QByteArray &value);
+
     /// Constructor.
     explicit O1(QObject *parent = 0, QNetworkAccessManager *manager = 0, O0AbstractStore *store = 0);
 


### PR DESCRIPTION
Hello @pipacs, I've got a suggestion and don't know if it is suitable for the existing class design.
Maybe you or I can pull replyServer_ from O1 and O2 up into O0BaseAuth?