### PR TITLE
Fix authorization failure with 127.0.0.1

### DIFF
--- a/src/o0globals.h
+++ b/src/o0globals.h
@@ -3,7 +3,7 @@
 
 // Common constants
 const char O2_ENCRYPTION_KEY[] = "12345678";
-const char O2_CALLBACK_URL[] = "http://127.0.0.1:%1/";
+const char O2_CALLBACK_URL[] = "http://localhost:%1/";
 const char O2_MIME_TYPE_XFORM[] = "application/x-www-form-urlencoded";
 const char O2_MIME_TYPE_JSON[] = "application/json";
 

--- a/src/o2.h
+++ b/src/o2.h
@@ -48,8 +48,7 @@ public:
     QString scope();
     void setScope(const QString &value);
 
-    /// Localhost policy. By default it's value is http://127.0.0.1:%1/, however some services may
-    /// require the use of http://localhost:%1/ or any other value.
+    /// Localhost policy. By default its value is http://localhost:%1/
     Q_PROPERTY(QString localhostPolicy READ localhostPolicy WRITE setLocalhostPolicy)
     QString localhostPolicy() const;
     void setLocalhostPolicy(const QString &value);


### PR DESCRIPTION
Hello @pipacs,
Is there any service, platform or browser that works better with 127.0.0.1 than with localhost?
I haven't found any explanation why 127.0.0.1 was preferred in commit history.