### PR TITLE
Remove unused const O2_OAUTH2_GRANT_TYPE_UBER_CODE to avoid warnings.

### DIFF
--- a/src/o2uber.cpp
+++ b/src/o2uber.cpp
@@ -18,8 +18,6 @@ static const char *UberTokenUrl = "https://login.uber.com/oauth/v2/token";
 static const char *UberExpiresIn = "expires_in";
 static const char *UberGrantType = "authorization_code";
 
-static const char O2_OAUTH2_GRANT_TYPE_UBER_CODE[] = "authorization_code";
-
 O2Uber::O2Uber(QObject *parent): O2(parent)
 {
     setRequestUrl(UberEndpoint);


### PR DESCRIPTION
The const O2_OAUTH2_GRANT_TYPE_UBER_CODE is unused and causes a warning depending on your build settings.