### PR TITLE
O2Requestor retry() fails for OAuth 2 services requiring access token to be sent as a Authentication HTTP header

### DIFF
--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -21,6 +21,10 @@ O2Requestor::O2Requestor(QNetworkAccessManager *manager, O2 *authenticator, QObj
 O2Requestor::~O2Requestor() {
 }
 
+void O2Requestor::setAccessTokenInAuthenticationHTTPHeaderFormat(const QString &value) {
+    accessTokenInAuthenticationHTTPHeaderFormat_ = value;
+}
+
 int O2Requestor::get(const QNetworkRequest &req) {
     if (-1 == setup(req, QNetworkAccessManager::GetOperation)) {
         return -1;
@@ -138,6 +142,12 @@ int O2Requestor::setup(const QNetworkRequest &req, QNetworkAccessManager::Operat
     url.setQuery(query);
 #endif
     request_.setUrl(url);
+	
+    // If the service require the access token to be sent as a Authentication HTTP header, we add the access token.
+    if(!accessTokenInAuthenticationHTTPHeaderFormat_.isEmpty()) {
+        request_.setRawHeader(O2_HTTP_AUTHORIZATION_HEADER, accessTokenInAuthenticationHTTPHeaderFormat_.arg(authenticator_->token()).toLatin1());
+    }
+	
     status_ = Requesting;
     error_ = QNetworkReply::NoError;
     return id_;
@@ -174,6 +184,13 @@ void O2Requestor::retry() {
     url.setQuery(query);
 #endif
     request_.setUrl(url);
+	
+    // If the service require the access token to be sent as a Authentication HTTP header,
+    // we update the access token when retrying.
+    if(!accessTokenInAuthenticationHTTPHeaderFormat_.isEmpty()) {
+        request_.setRawHeader(O2_HTTP_AUTHORIZATION_HEADER, accessTokenInAuthenticationHTTPHeaderFormat_.arg(authenticator_->token()).toLatin1());
+    }
+	
     status_ = ReRequesting;
     switch (operation_) {
     case QNetworkAccessManager::GetOperation:

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -20,6 +20,12 @@ class O0_EXPORT O2Requestor: public QObject {
 public:
     explicit O2Requestor(QNetworkAccessManager *manager, O2 *authenticator, QObject *parent = 0);
     ~O2Requestor();
+    
+    /// Some services require the access token to be sent as a Authentication HTTP header.
+    /// This is the case for Twitch and Mixer.
+    /// When the access token expires and is refreshed, O2Requestor::retry() needs to update the Authentication HTTP header.
+    /// In order to do so, O2Requestor needs to know the format of the Authentication HTTP header.
+    void setAccessTokenInAuthenticationHTTPHeaderFormat(const QString &value);
 
 public Q_SLOTS:
     /// Make a GET request.
@@ -78,6 +84,7 @@ protected:
     QUrl url_;
     O2ReplyList timedReplies_;
     QNetworkReply::NetworkError error_;
+    QString accessTokenInAuthenticationHTTPHeaderFormat_;
 };
 
 #endif // O2REQUESTOR_H


### PR DESCRIPTION
Some OAuth 2 services require the access token to be sent as a Authentication HTTP header. This is the case for Twitch and Mixer which require respectively an 'OAuth' and 'Bearer' header for OAuth 2.

For those special cases, O2Requestor fails when retrying because the Authentication HTTP header is not updated with the new access token: when the access token expires and is refreshed, O2Requestor::retry() needs to update the Authentication HTTP header. In order to do so, O2Requestor needs to know the format of the Authentication HTTP header.

This change adds an optional property 'accessTokenInAuthenticationHTTPHeaderFormat_' to O2Requestor to make it work which those services.