### PR TITLE
Prevent crash in O2Requestor::onRequestFinished()

### DIFF
--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -76,15 +76,13 @@ void O2Requestor::onRefreshFinished(QNetworkReply::NetworkError error) {
 }
 
 void O2Requestor::onRequestFinished() {
-    QNetworkReply *senderReply = qobject_cast<QNetworkReply *>(sender());
-    QNetworkReply::NetworkError error = senderReply->error();
     if (status_ == Idle) {
         return;
     }
-    if (reply_ != senderReply) {
+    if (reply_ != qobject_cast<QNetworkReply *>(sender())) {
         return;
     }
-    if (error == QNetworkReply::NoError) {
+    if (reply_->error() == QNetworkReply::NoError) {
         QTimer::singleShot(10, this, SLOT(finish()));
     }
 }


### PR DESCRIPTION
We have seen some crashes in O2Requestor::onRequestFinished(). When the sender() is cast to QNetworkReply*, the pointer is not checked and this can led to a NULL dereference when calling senderReply->error().

The fix consists of performing the safety checks in the same order as O2Requestor::onRequestError(). The pointer dereference occurs only after  reply_ == senderReply which should prevent the crash.