### PR TITLE
Add support for custom requests (PATCH for example)

### DIFF
--- a/src/o0globals.h
+++ b/src/o0globals.h
@@ -57,6 +57,7 @@ const char O2_SIGNATURE_TYPE_PLAINTEXT[] = "PLAINTEXT";
 const char O2_AUTHORIZATION_CODE[] = "authorization_code";
 
 // Standard HTTP headers
+const char O2_HTTP_HTTP_HEADER[] = "HTTP";
 const char O2_HTTP_AUTHORIZATION_HEADER[] = "Authorization";
 
 #endif // O0GLOBALS_H

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -40,7 +40,12 @@ public Q_SLOTS:
     /// @return Request ID or -1 if there are too many requests in the queue.
     int put(const QNetworkRequest &req, const QByteArray &data);
 
+    /// Make a custom request.
+    /// @return Request ID or -1 if there are too many requests in the queue.
+    int customRequest(const QNetworkRequest &req, const QByteArray &verb, const QByteArray &data);
+
 Q_SIGNALS:
+
     /// Emitted when a request has been completed or failed.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data);
 
@@ -67,7 +72,7 @@ protected Q_SLOTS:
     void onUploadProgress(qint64 uploaded, qint64 total);
 
 protected:
-    int setup(const QNetworkRequest &request, QNetworkAccessManager::Operation operation);
+    int setup(const QNetworkRequest &request, QNetworkAccessManager::Operation operation, const QByteArray &verb = QByteArray());
 
     enum Status {
         Idle, Requesting, ReRequesting


### PR DESCRIPTION
Some services like Mixer have PATCH requests. O2 is currently unable to perform those.  The new function customRequest() allows you to create such custom requests.