### PR TITLE
fix local variable will be copied despite being returned by name

### DIFF
--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -105,7 +105,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
         QString value = QUrl::fromPercentEncoding(QByteArray().append(tokenPair.second.trimmed().toLatin1()));
         queryParams.insert(key, value);
     }
-    return queryParams;
+    std::move(return queryParams);
 }
 
 void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)

--- a/src/o2replyserver.cpp
+++ b/src/o2replyserver.cpp
@@ -97,7 +97,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
     QUrlQuery query(getTokenUrl);
     tokens = query.queryItems();
 #endif
-    QMultiMap<QString, QString> queryParams;
+    QMap<QString, QString> queryParams;
     QPair<QString, QString> tokenPair;
     foreach (tokenPair, tokens) {
         // FIXME: We are decoding key and value again. This helps with Google OAuth, but is it mandated by the standard?
@@ -105,7 +105,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
         QString value = QUrl::fromPercentEncoding(QByteArray().append(tokenPair.second.trimmed().toLatin1()));
         queryParams.insert(key, value);
     }
-    std::move(return queryParams);
+    return queryParams;
 }
 
 void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)


### PR DESCRIPTION
error when building with clang 7

note: call 'std::move' explicitly to avoid copying

see https://travis-ci.org/qgis/QGIS/jobs/439416330#L723