### PR TITLE
Add support for RFC8628 and Google Sign-In for TVs and Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ O2 | o2.h | Generic OAuth 2.0 authenticator
 O2Facebook | o2facebook.h | Facebook OAuth specialization
 O2Gft | o2gft.h | Google Fusion Tables OAuth specialization
 O2Google | o2google.h | Google Oauth specialization [scopes](https://developers.google.com/identity/protocols/googlescopes)
+O2GoogleDevice | o2google.h | Google [Sign-In for TVs and Devices](https://developers.google.com/identity/sign-in/devices)
 O2Hubic | o2hubic.h | Hubic OAuth specialization
 O2Msgraph | o2msgraph.h | Microsoft Graph OAuth specialization
 O2Reply | o2reply.h | A network request/reply that can time out

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ endif(NOT o2_WITH_QT5)
 
 set( o2_SRCS
     o2.cpp
+    o2pollserver.cpp
     o2reply.cpp
     o2replyserver.cpp
     o2requestor.cpp
@@ -31,6 +32,7 @@ set( o2_SRCS
 
 set( o2_HDRS
     o2.h
+    o2pollserver.h
     o2reply.h
     o2replyserver.h
     o2requestor.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,11 +86,13 @@ if(o2_WITH_GOOGLE)
         ${o2_SRCS}
         o2gft.cpp
         o2google.cpp
+        o2googledevice.cpp
     )
     set( o2_HDRS
         ${o2_HDRS}
         o2gft.h
         o2google.h
+        o2googledevice.h
     )
 endif(o2_WITH_GOOGLE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set( o2_SRCS
     o2replyserver.cpp
     o2requestor.cpp
     o2simplecrypt.cpp
+    o0jsonresponse.cpp
     o0settingsstore.cpp
     o0baseauth.cpp
 )
@@ -37,6 +38,7 @@ set( o2_HDRS
     o0baseauth.h
     o0export.h
     o0globals.h
+    o0jsonresponse.h
     o0requestparameter.h
     o0settingsstore.h
     o0simplecrypt.h

--- a/src/o0baseauth.cpp
+++ b/src/o0baseauth.cpp
@@ -6,10 +6,11 @@
 #include "o0globals.h"
 #include "o0settingsstore.h"
 #include "o2replyserver.h"
+#include "o2pollserver.h"
 
 static const quint16 DefaultLocalPort = 1965;
 
-O0BaseAuth::O0BaseAuth(QObject *parent, O0AbstractStore *store): QObject(parent), store_(0), useExternalWebInterceptor_(false), replyServer_(NULL) {
+O0BaseAuth::O0BaseAuth(QObject *parent, O0AbstractStore *store): QObject(parent), store_(0), useExternalWebInterceptor_(false), replyServer_(NULL), pollServer_(NULL) {
     localPort_ = DefaultLocalPort;
     setStore(store);
 }
@@ -143,6 +144,19 @@ void O0BaseAuth::setReplyServer(O2ReplyServer * server)
 O2ReplyServer * O0BaseAuth::replyServer() const
 {
     return replyServer_;
+}
+
+void O0BaseAuth::setPollServer(O2PollServer *server)
+{
+    if (pollServer_)
+        pollServer_->deleteLater();
+
+    pollServer_ = server;
+}
+
+O2PollServer *O0BaseAuth::pollServer() const
+{
+    return pollServer_;
 }
 
 QByteArray O0BaseAuth::createQueryParameters(const QList<O0RequestParameter> &parameters) {

--- a/src/o0baseauth.h
+++ b/src/o0baseauth.h
@@ -13,6 +13,7 @@
 #include "o0requestparameter.h"
 
 class O2ReplyServer;
+class O2PollServer;
 
 /// Base class of OAuth authenticators
 class O0_EXPORT O0BaseAuth : public QObject {
@@ -88,6 +89,9 @@ Q_SIGNALS:
     /// Emitted when client can close the browser window.
     void closeBrowser();
 
+    /// Emitted when client needs to show a verification uri and user code
+    void showVerificationUriAndCode(const QUrl &uri, const QString &code);
+
     /// Emitted when authentication/deauthentication succeeded.
     void linkingSucceeded();
 
@@ -122,6 +126,11 @@ protected:
 
     O2ReplyServer * replyServer() const;
 
+    /// Set local poll server
+    void setPollServer(O2PollServer *server);
+
+    O2PollServer * pollServer() const;
+
 protected:
     QString clientId_;
     QString clientSecret_;
@@ -139,6 +148,7 @@ protected:
 
 private:
     O2ReplyServer *replyServer_;
+    O2PollServer *pollServer_;
 };
 
 #endif // O0BASEAUTH

--- a/src/o0globals.h
+++ b/src/o0globals.h
@@ -41,14 +41,22 @@ const char O2_OAUTH2_SCOPE[] = "scope";
 const char O2_OAUTH2_GRANT_TYPE_CODE[] = "code";
 const char O2_OAUTH2_GRANT_TYPE_TOKEN[] = "token";
 const char O2_OAUTH2_GRANT_TYPE_PASSWORD[] = "password";
+const char O2_OAUTH2_GRANT_TYPE_DEVICE[] = "urn:ietf:params:oauth:grant-type:device_code";
 const char O2_OAUTH2_GRANT_TYPE[] = "grant_type";
 const char O2_OAUTH2_API_KEY[] = "api_key";
 const char O2_OAUTH2_STATE[] = "state";
+const char O2_OAUTH2_CODE[] = "code";
 
 // OAuth 2 Response Parameters
 const char O2_OAUTH2_ACCESS_TOKEN[] = "access_token";
 const char O2_OAUTH2_REFRESH_TOKEN[] = "refresh_token";
 const char O2_OAUTH2_EXPIRES_IN[] = "expires_in";
+const char O2_OAUTH2_DEVICE_CODE[] = "device_code";
+const char O2_OAUTH2_USER_CODE[] = "user_code";
+const char O2_OAUTH2_VERIFICATION_URI[] = "verification_uri";
+const char O2_OAUTH2_VERIFICATION_URL[] = "verification_url"; // Google sign-in
+const char O2_OAUTH2_VERIFICATION_URI_COMPLETE[] = "verification_uri_complete";
+const char O2_OAUTH2_INTERVAL[] = "interval";
 
 // OAuth signature types
 const char O2_SIGNATURE_TYPE_HMAC_SHA1[] = "HMAC-SHA1";

--- a/src/o0jsonresponse.cpp
+++ b/src/o0jsonresponse.cpp
@@ -1,0 +1,40 @@
+#include "o0jsonresponse.h"
+
+#include <QByteArray>
+#if QT_VERSION >= 0x050000
+#include <QJsonDocument>
+#include <QJsonObject>
+#else
+#include <QScriptEngine>
+#include <QScriptValueIterator>
+#endif
+
+QVariantMap parseJsonResponse(const QByteArray &data) {
+#if QT_VERSION >= 0x050000
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+    if (err.error != QJsonParseError::NoError) {
+        qWarning() << "parseTokenResponse: Failed to parse token response due to err:" << err.errorString();
+        return QVariantMap();
+    }
+
+    if (!doc.isObject()) {
+        qWarning() << "parseTokenResponse: Token response is not an object";
+        return QVariantMap();
+    }
+
+    return doc.object().toVariantMap();
+#else
+    QScriptEngine engine;
+    QScriptValue value = engine.evaluate("(" + QString(data) + ")");
+    QScriptValueIterator it(value);
+    QVariantMap map;
+
+    while (it.hasNext()) {
+        it.next();
+        map.insert(it.name(), it.value().toVariant());
+    }
+
+    return map;
+#endif
+}

--- a/src/o0jsonresponse.h
+++ b/src/o0jsonresponse.h
@@ -1,0 +1,11 @@
+#ifndef O0JSONRESPONSE_H
+#define O0JSONRESPONSE_H
+
+#include <QVariantMap>
+
+class QByteArray;
+
+/// Parse JSON data into a QVariantMap
+QVariantMap parseJsonResponse(const QByteArray &data);
+
+#endif // O0JSONRESPONSE_H

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "o2.h"
+#include "o2pollserver.h"
 #include "o2replyserver.h"
 #include "o0globals.h"
 #include "o0jsonresponse.h"
@@ -31,6 +32,25 @@ static void addQueryParametersToUrl(QUrl &url,  QList<QPair<QString, QString> > 
     query.setQueryItems(parameters);
     url.setQuery(query);
 #endif
+}
+
+// ref: https://tools.ietf.org/html/rfc8628#section-3.2
+// Exception: Google sign-in uses "verification_url" instead of "*_uri" - we'll accept both.
+static bool hasMandatoryDeviceAuthParams(const QVariantMap& params)
+{
+    if (!params.contains(O2_OAUTH2_DEVICE_CODE))
+        return false;
+
+    if (!params.contains(O2_OAUTH2_USER_CODE))
+        return false;
+
+    if (!(params.contains(O2_OAUTH2_VERIFICATION_URI) || params.contains(O2_OAUTH2_VERIFICATION_URL)))
+        return false;
+
+    if (!params.contains(O2_OAUTH2_EXPIRES_IN))
+        return false;
+
+    return true;
 }
 
 O2::O2(QObject *parent, QNetworkAccessManager *manager, O0AbstractStore *store): O0BaseAuth(parent, store) {
@@ -112,6 +132,30 @@ QString O2::refreshTokenUrl() {
 void O2::setRefreshTokenUrl(const QString &value) {
     refreshTokenUrl_ = value;
     Q_EMIT refreshTokenUrlChanged();
+}
+
+QString O2::grantType()
+{
+    if (!grantType_.isEmpty())
+        return grantType_;
+
+    switch (grantFlow_) {
+    case GrantFlowAuthorizationCode:
+        return O2_OAUTH2_GRANT_TYPE_CODE;
+    case GrantFlowImplicit:
+        return O2_OAUTH2_GRANT_TYPE_TOKEN;
+    case GrantFlowResourceOwnerPasswordCredentials:
+        return O2_OAUTH2_GRANT_TYPE_PASSWORD;
+    case GrantFlowDevice:
+        return O2_OAUTH2_GRANT_TYPE_DEVICE;
+    }
+
+    return QString();
+}
+
+void O2::setGrantType(const QString &value)
+{
+    grantType_ = value;
 }
 
 void O2::link() {
@@ -207,6 +251,20 @@ void O2::link() {
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
     }
+    else if (grantFlow_ == GrantFlowDevice) {
+        QList<O0RequestParameter> parameters;
+        parameters.append(O0RequestParameter(O2_OAUTH2_CLIENT_ID, clientId_.toUtf8()));
+        parameters.append(O0RequestParameter(O2_OAUTH2_SCOPE, scope_.toUtf8()));
+        QByteArray payload = O0BaseAuth::createQueryParameters(parameters);
+
+        QUrl url(requestUrl_);
+        QNetworkRequest deviceRequest(url);
+        deviceRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+        QNetworkReply *tokenReply = manager_->post(deviceRequest, payload);
+
+        connect(tokenReply, SIGNAL(finished()), this, SLOT(onDeviceAuthReplyFinished()), Qt::QueuedConnection);
+        connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+    }
 }
 
 void O2::unlink() {
@@ -254,10 +312,10 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         timedReplies_.add(tokenReply);
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
-    } else if (grantFlow_ == GrantFlowImplicit) {
+    } else if (grantFlow_ == GrantFlowImplicit || grantFlow_ == GrantFlowDevice) {
       // Check for mandatory tokens
       if (response.contains(O2_OAUTH2_ACCESS_TOKEN)) {
-          qDebug() << "O2::onVerificationReceived: Access token returned for implicit flow";
+          qDebug() << "O2::onVerificationReceived: Access token returned for implicit or device flow";
           setToken(response.value(O2_OAUTH2_ACCESS_TOKEN));
           if (response.contains(O2_OAUTH2_EXPIRES_IN)) {
             bool ok = false;
@@ -267,10 +325,13 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
                 setExpires((int)(QDateTime::currentMSecsSinceEpoch() / 1000 + expiresIn));
             }
           }
+          if (response.contains(O2_OAUTH2_REFRESH_TOKEN)) {
+              setRefreshToken(response.value(O2_OAUTH2_REFRESH_TOKEN));
+          }
           setLinked(true);
           Q_EMIT linkingSucceeded();
       } else {
-          qWarning() << "O2::onVerificationReceived: Access token missing from response for implicit flow";
+          qWarning() << "O2::onVerificationReceived: Access token missing from response for implicit or device flow";
           Q_EMIT linkingFailed();
       }
     } else {
@@ -378,6 +439,45 @@ void O2::setExpires(int v) {
     store_->setValue(key, QString::number(v));
 }
 
+void O2::startPollServer(const QVariantMap &params)
+{
+    bool ok = false;
+    int expiresIn = params[O2_OAUTH2_EXPIRES_IN].toInt(&ok);
+    if (!ok) {
+        qWarning() << "O2::startPollServer: No expired_in parameter";
+        Q_EMIT linkingFailed();
+        return;
+    }
+
+    qDebug() << "O2::startPollServer: device_ and user_code expires in" << expiresIn << "seconds";
+
+    QUrl url(tokenUrl_);
+    QNetworkRequest authRequest(url);
+    authRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+
+    const QString deviceCode = params[O2_OAUTH2_DEVICE_CODE].toString();
+    const QString grantType = grantType_.isEmpty() ? O2_OAUTH2_GRANT_TYPE_DEVICE : grantType_;
+
+    QList<O0RequestParameter> parameters;
+    parameters.append(O0RequestParameter(O2_OAUTH2_CLIENT_ID, clientId_.toUtf8()));
+    if ( !clientSecret_.isEmpty() )
+        parameters.append(O0RequestParameter(O2_OAUTH2_CLIENT_SECRET, clientSecret_.toUtf8()));
+    parameters.append(O0RequestParameter(O2_OAUTH2_CODE, deviceCode.toUtf8()));
+    parameters.append(O0RequestParameter(O2_OAUTH2_GRANT_TYPE, grantType.toUtf8()));
+    QByteArray payload = O0BaseAuth::createQueryParameters(parameters);
+
+    O2PollServer * pollServer = new O2PollServer(manager_, authRequest, payload, expiresIn, this);
+    if (params.contains(O2_OAUTH2_INTERVAL)) {
+        int interval = params[O2_OAUTH2_INTERVAL].toInt(&ok);
+        if (ok)
+            pollServer->setInterval(interval);
+    }
+    connect(pollServer, SIGNAL(verificationReceived(QMap<QString,QString>)), this, SLOT(onVerificationReceived(QMap<QString,QString>)));
+    connect(pollServer, SIGNAL(serverClosed(bool)), this, SLOT(serverHasClosed(bool)));
+    setPollServer(pollServer);
+    pollServer->startPolling();
+}
+
 QString O2::refreshToken() {
     QString key = QString(O2_KEY_REFRESH_TOKEN).arg(clientId_);
     return store_->value(key);
@@ -452,12 +552,63 @@ void O2::onRefreshError(QNetworkReply::NetworkError error) {
     Q_EMIT refreshFinished(error);
 }
 
+void O2::onDeviceAuthReplyFinished()
+{
+    qDebug() << "O2::onDeviceAuthReplyFinished";
+    QNetworkReply *tokenReply = qobject_cast<QNetworkReply *>(sender());
+    if (!tokenReply)
+    {
+      qDebug() << "O2::onDeviceAuthReplyFinished: reply is null";
+      return;
+    }
+    if (tokenReply->error() == QNetworkReply::NoError) {
+        QByteArray replyData = tokenReply->readAll();
+
+        // Dump replyData
+        // SENSITIVE DATA in RelWithDebInfo or Debug builds
+        //qDebug() << "O2::onDeviceAuthReplyFinished: replyData\n";
+        //qDebug() << QString( replyData );
+
+        QVariantMap params = parseJsonResponse(replyData);
+
+        // Dump tokens
+        qDebug() << "O2::onDeviceAuthReplyFinished: Tokens returned:\n";
+        foreach (QString key, params.keys()) {
+            // SENSITIVE DATA in RelWithDebInfo or Debug builds, so it is truncated first
+            qDebug() << key << ": "<< params.value( key ).toString().left( 3 ) << "...";
+        }
+
+        // Check for mandatory parameters
+        if (hasMandatoryDeviceAuthParams(params)) {
+            qDebug() << "O2::onDeviceAuthReplyFinished: Device auth request response";
+
+            const QString userCode = params.take(O2_OAUTH2_USER_CODE).toString();
+            QUrl uri = params.take(O2_OAUTH2_VERIFICATION_URI).toUrl();
+            if (uri.isEmpty())
+                uri = params.take(O2_OAUTH2_VERIFICATION_URL).toUrl();
+
+            if (params.contains(O2_OAUTH2_VERIFICATION_URI_COMPLETE))
+                Q_EMIT openBrowser(params.take(O2_OAUTH2_VERIFICATION_URI_COMPLETE).toUrl());
+
+            Q_EMIT showVerificationUriAndCode(uri, userCode);
+
+            startPollServer(params);
+        } else {
+            qWarning() << "O2::onDeviceAuthReplyFinished: Mandatory parameters missing from response";
+            Q_EMIT linkingFailed();
+        }
+    }
+    tokenReply->deleteLater();
+}
+
 void O2::serverHasClosed(bool paramsfound)
 {
     if ( !paramsfound ) {
         // server has probably timed out after receiving first response
         Q_EMIT linkingFailed();
     }
+    // poll server is not re-used for later auth requests
+    setPollServer(NULL);
 }
 
 QString O2::localhostPolicy() const {

--- a/src/o2.h
+++ b/src/o2.h
@@ -22,6 +22,7 @@ public:
         GrantFlowAuthorizationCode, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.1
         GrantFlowImplicit, ///< @see http://tools.ietf.org/html/draft-ietf-oauth-v2-15#section-4.2
         GrantFlowResourceOwnerPasswordCredentials,
+        GrantFlowDevice ///< @see https://tools.ietf.org/html/rfc8628#section-1
     };
 
     /// Authorization flow.
@@ -83,6 +84,11 @@ public:
     QString refreshTokenUrl();
     void setRefreshTokenUrl(const QString &value);
 
+    /// Grant type (if non-standard)
+    Q_PROPERTY(QString grantType READ grantType WRITE setGrantType);
+    QString grantType();
+    void setGrantType(const QString &value);
+
 public:
     /// Constructor.
     /// @param  parent  Parent object.
@@ -141,6 +147,9 @@ protected Q_SLOTS:
     /// Handle failure of a refresh request.
     virtual void onRefreshError(QNetworkReply::NetworkError error);
 
+    /// Handle completion of a Device Authorization Request
+    virtual void onDeviceAuthReplyFinished();
+
 protected:
     /// Build HTTP request body.
     QByteArray buildRequestBody(const QMap<QString, QString> &parameters);
@@ -153,6 +162,9 @@ protected:
 
     /// Set token expiration time.
     void setExpires(int v);
+
+    /// Start polling authorization server
+    void startPollServer(const QVariantMap &params);
 
 protected:
     QString username_;
@@ -168,6 +180,7 @@ protected:
     QNetworkAccessManager *manager_;
     O2ReplyList timedReplies_;
     GrantFlow grantFlow_;
+    QString grantType_;
 };
 
 #endif // O2_H

--- a/src/o2googledevice.cpp
+++ b/src/o2googledevice.cpp
@@ -1,0 +1,13 @@
+#include "o2googledevice.h"
+
+static const char *GoogleDeviceEndpoint = "https://oauth2.googleapis.com/device/code";
+// Google uses a different grant type value than specified in RFC 8628
+static const char *GoogleDeviceGrantType = "http://oauth.net/grant_type/device/1.0";
+
+O2GoogleDevice::O2GoogleDevice(QObject *parent) : O2Google(parent) {
+    setGrantFlow(GrantFlowDevice);
+    setGrantType(GoogleDeviceGrantType);
+    // O2Google() already set the correct token and refresh token URLs.
+    // However, the request endpoint is different.
+    setRequestUrl(GoogleDeviceEndpoint);
+}

--- a/src/o2googledevice.h
+++ b/src/o2googledevice.h
@@ -1,0 +1,16 @@
+#ifndef O2GOOGLEDEVICE_H
+#define O2GOOGLEDEVICE_H
+
+#include "o0export.h"
+#include "o2google.h"
+
+/// "Google Sign-In for TVs and Devices",
+/// A dialect of RFC 8628: OAuth 2.0 Device Authorization Grant
+class O0_EXPORT O2GoogleDevice : public O2Google {
+    Q_OBJECT
+
+public:
+    explicit O2GoogleDevice(QObject *parent = 0);
+};
+
+#endif // O2GOOGLEDEVICE_H

--- a/src/o2pollserver.cpp
+++ b/src/o2pollserver.cpp
@@ -1,0 +1,123 @@
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+
+#include "o2pollserver.h"
+#include "o0jsonresponse.h"
+
+static QMap<QString, QString> toVerificationParams(const QVariantMap &map)
+{
+    QMap<QString, QString> params;
+    for (QVariantMap::const_iterator i = map.constBegin();
+         i != map.constEnd(); ++i)
+    {
+        params[i.key()] = i.value().toString();
+    }
+    return params;
+}
+
+O2PollServer::O2PollServer(QNetworkAccessManager *manager, const QNetworkRequest &request, const QByteArray &payload, int expiresIn, QObject *parent)
+    : QObject(parent)
+    , manager_(manager)
+    , request_(request)
+    , payload_(payload)
+    , expiresIn_(expiresIn)
+{
+    expirationTimer.setTimerType(Qt::VeryCoarseTimer);
+    expirationTimer.setInterval(expiresIn * 1000);
+    expirationTimer.setSingleShot(true);
+    connect(&expirationTimer, SIGNAL(timeout()), this, SLOT(onExpiration()));
+    expirationTimer.start();
+
+    pollTimer.setTimerType(Qt::VeryCoarseTimer);
+    pollTimer.setInterval(5 * 1000);
+    pollTimer.setSingleShot(true);
+    connect(&pollTimer, SIGNAL(timeout()), this, SLOT(onPollTimeout()));
+}
+
+int O2PollServer::interval() const
+{
+    return pollTimer.interval() / 1000;
+}
+
+void O2PollServer::setInterval(int interval)
+{
+    pollTimer.setInterval(interval * 1000);
+}
+
+void O2PollServer::startPolling()
+{
+    if (expirationTimer.isActive()) {
+        // don't wait for poll timeout before firing the first request
+        onPollTimeout();
+    }
+}
+
+void O2PollServer::onPollTimeout()
+{
+    qDebug() << "O2PollServer::onPollTimeout: retrying";
+    QNetworkReply * reply = manager_->post(request_, payload_);
+    connect(reply, SIGNAL(finished()), this, SLOT(onReplyFinished()));
+}
+
+void O2PollServer::onExpiration()
+{
+    pollTimer.stop();
+    Q_EMIT serverClosed(false);
+}
+
+void O2PollServer::onReplyFinished()
+{
+    QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
+
+    if (!reply) {
+        qDebug() << "O2PollServer::onReplyFinished: reply is null";
+        return;
+    }
+
+    QByteArray replyData = reply->readAll();
+    QMap<QString, QString> params = toVerificationParams(parseJsonResponse(replyData));
+
+    // Dump replyData
+    // SENSITIVE DATA in RelWithDebInfo or Debug builds
+    // qDebug() << "O2PollServer::onReplyFinished: replyData\n";
+    // qDebug() << QString( replyData );
+
+    if (reply->error() == QNetworkReply::NoError) {
+        expirationTimer.stop();
+        Q_EMIT serverClosed(true);
+        Q_EMIT verificationReceived(params);
+    }
+    else if (reply->error() == QNetworkReply::TimeoutError) {
+        // rfc8628#section-3.2
+        // "On encountering a connection timeout, clients MUST unilaterally
+        // reduce their polling frequency before retrying.  The use of an
+        // exponential backoff algorithm to achieve this, such as doubling the
+        // polling interval on each such connection timeout, is RECOMMENDED."
+        setInterval(interval() * 2);
+        pollTimer.start();
+    }
+    else {
+        QString error = params.value("error");
+        if (error == "slow_down") {
+            // rfc8628#section-3.2
+            // "A variant of 'authorization_pending', the authorization request is
+            // still pending and polling should continue, but the interval MUST
+            // be increased by 5 seconds for this and all subsequent requests."
+            setInterval(interval() + 5);
+            pollTimer.start();
+        }
+        else if (error == "authorization_pending") {
+            // keep trying - rfc8628#section-3.2
+            // "The authorization request is still pending as the end user hasn't
+            // yet completed the user-interaction steps (Section 3.3)."
+            pollTimer.start();
+        }
+        else {
+            expirationTimer.stop();
+            Q_EMIT serverClosed(true);
+            // let O2 handle the other errors
+            Q_EMIT verificationReceived(params);
+        }
+    }
+    reply->deleteLater();
+}

--- a/src/o2pollserver.h
+++ b/src/o2pollserver.h
@@ -1,0 +1,49 @@
+#ifndef O2POLLSERVER_H
+#define O2POLLSERVER_H
+
+#include <QByteArray>
+#include <QMap>
+#include <QNetworkRequest>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+#include "o0export.h"
+
+class QNetworkAccessManager;
+
+/// Poll an authorization server for token
+class O0_EXPORT O2PollServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit O2PollServer(QNetworkAccessManager * manager, const QNetworkRequest &request, const QByteArray & payload, int expiresIn, QObject *parent = nullptr);
+
+    /// Seconds to wait between polling requests
+    Q_PROPERTY(int interval READ interval WRITE setInterval)
+    int interval() const;
+    void setInterval(int interval);
+
+Q_SIGNALS:
+    void verificationReceived(QMap<QString, QString>);
+    void serverClosed(bool); // whether it has found parameters
+
+public Q_SLOTS:
+    void startPolling();
+
+protected Q_SLOTS:
+    void onPollTimeout();
+    void onExpiration();
+    void onReplyFinished();
+
+protected:
+    QNetworkAccessManager *manager_;
+    const QNetworkRequest request_;
+    const QByteArray payload_;
+    const int expiresIn_;
+    QTimer expirationTimer;
+    QTimer pollTimer;
+};
+
+#endif // O2POLLSERVER_H


### PR DESCRIPTION
Google employs a dialect of RFC8628 for their "Google Sign-In for TVs and Devices". Some constants are different, but the main grant flow is the same.

This is what Google does different from RFC8628 (that I've found):
* Google sets the grant type to `http://oauth.net/grant_type/device/1.0` whereas RFC8628 defines it as `urn:ietf:params:oauth:grant-type:device_code`
* Google uses `verification_url` instead of `*_uri` in their _Device Authorization Response_.
* Google uses various HTTP response codes for e.g. `authorization_pending`, `slow_down`, and other errors in their _Device Access Token Response_ whilst RFC8628 says the HTTP response code should always be `400`.