### PR TITLE
Don't print response in O2::onVerificationReceived()

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -255,7 +255,6 @@ void O2::unlink() {
 }
 
 void O2::onVerificationReceived(const QMap<QString, QString> response) {
-    qDebug() << "O2::onVerificationReceived:" << response;
     qDebug() << "O2::onVerificationReceived: Emitting closeBrowser()";
     Q_EMIT closeBrowser();
 


### PR DESCRIPTION
The response might contain access or refresh tokens that are considered
sensitive data.