### PR TITLE
Build system fixes

### DIFF
--- a/o2.pc.cmake
+++ b/o2.pc.cmake
@@ -7,4 +7,4 @@ Description: OAuth 2.0 for Qt
 Version: @PROJECT_VERSION@
 
 Cflags: -I${includedir} @CMAKE_INCLUDE_PATH@
-Libs: -L${libdir} @CMAKE_LIBRARY_PATH@
+Libs: -L${libdir} -lo2

--- a/src/src.pri
+++ b/src/src.pri
@@ -21,6 +21,7 @@ SOURCES += \
     $$PWD/o0settingsstore.cpp \
     $$PWD/o2spotify.cpp \
     $$PWD/o2google.cpp \
+    $$PWD/o2googledevice.cpp \
     $$PWD/o2uber.cpp \
     $$PWD/o2msgraph.cpp
 
@@ -50,5 +51,6 @@ HEADERS += \
     $$PWD/o0settingsstore.h \
     $$PWD/o2spotify.h \
     $$PWD/o2google.h \
+    $$PWD/o2googledevice.h \
     $$PWD/o2uber.h \
     $$PWD/o2msgraph.h


### PR DESCRIPTION
Two minor changes:
* Added o2googledevice.{cpp,h} to _src.pri_
* Set the linker flags in _o2.pc.cmake_ to `-lo2` instead of `@CMAKE_LIBRARY_PATH@`. In fact, `@CMAKE_LIBRARY_PATH@` would produce a "Semicolon-separated list of directories..." which is not what is wanted.