### PR TITLE
Minor fixes for old toolchains

### DIFF
--- a/src/o0jsonresponse.cpp
+++ b/src/o0jsonresponse.cpp
@@ -1,6 +1,7 @@
 #include "o0jsonresponse.h"
 
 #include <QByteArray>
+#include <QDebug>
 #if QT_VERSION >= 0x050000
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/o2pollserver.h
+++ b/src/o2pollserver.h
@@ -18,7 +18,7 @@ class O0_EXPORT O2PollServer : public QObject
     Q_OBJECT
 
 public:
-    explicit O2PollServer(QNetworkAccessManager * manager, const QNetworkRequest &request, const QByteArray & payload, int expiresIn, QObject *parent = nullptr);
+    explicit O2PollServer(QNetworkAccessManager * manager, const QNetworkRequest &request, const QByteArray & payload, int expiresIn, QObject *parent = 0);
 
     /// Seconds to wait between polling requests
     Q_PROPERTY(int interval READ interval WRITE setInterval)


### PR DESCRIPTION
My embedded board toolchain is ancient (gcc-4.5.3) and failed to build o2 without these fixes