### PR TITLE
Fix pollserver

### DIFF
--- a/src/o2pollserver.cpp
+++ b/src/o2pollserver.cpp
@@ -82,12 +82,7 @@ void O2PollServer::onReplyFinished()
     // qDebug() << "O2PollServer::onReplyFinished: replyData\n";
     // qDebug() << QString( replyData );
 
-    if (reply->error() == QNetworkReply::NoError) {
-        expirationTimer.stop();
-        Q_EMIT serverClosed(true);
-        Q_EMIT verificationReceived(params);
-    }
-    else if (reply->error() == QNetworkReply::TimeoutError) {
+    if (reply->error() == QNetworkReply::TimeoutError) {
         // rfc8628#section-3.2
         // "On encountering a connection timeout, clients MUST unilaterally
         // reduce their polling frequency before retrying.  The use of an
@@ -115,7 +110,7 @@ void O2PollServer::onReplyFinished()
         else {
             expirationTimer.stop();
             Q_EMIT serverClosed(true);
-            // let O2 handle the other errors
+            // let O2 handle the other cases
             Q_EMIT verificationReceived(params);
         }
     }

--- a/src/o2pollserver.cpp
+++ b/src/o2pollserver.cpp
@@ -47,8 +47,7 @@ void O2PollServer::setInterval(int interval)
 void O2PollServer::startPolling()
 {
     if (expirationTimer.isActive()) {
-        // don't wait for poll timeout before firing the first request
-        onPollTimeout();
+        pollTimer.start();
     }
 }
 


### PR DESCRIPTION
Two changes:
* `QNetworkReply::error()` will return `NoError` even when there was an HTTP error response code. This change make sure that the error field of the json response is always checked for "authorization_pending" or "slow_down".
* Don't start polling right away. Nobody's that fast on their phone to approve the device before the first poll request.

