### PR TITLE
Update URLs used for O2GoogleDevice

### DIFF
--- a/src/o2googledevice.cpp
+++ b/src/o2googledevice.cpp
@@ -1,13 +1,15 @@
 #include "o2googledevice.h"
 
+static const char *GoogleDeviceTokenUrl = "https://oauth2.googleapis.com/token";
+static const char *GoogleDeviceRefreshUrl = "https://oauth2.googleapis.com/token";
 static const char *GoogleDeviceEndpoint = "https://oauth2.googleapis.com/device/code";
 // Google uses a different grant type value than specified in RFC 8628
 static const char *GoogleDeviceGrantType = "http://oauth.net/grant_type/device/1.0";
 
-O2GoogleDevice::O2GoogleDevice(QObject *parent) : O2Google(parent) {
+O2GoogleDevice::O2GoogleDevice(QObject *parent) : O2(parent) {
     setGrantFlow(GrantFlowDevice);
     setGrantType(GoogleDeviceGrantType);
-    // O2Google() already set the correct token and refresh token URLs.
-    // However, the request endpoint is different.
     setRequestUrl(GoogleDeviceEndpoint);
+    setTokenUrl(GoogleDeviceTokenUrl);
+    setRefreshTokenUrl(GoogleDeviceRefreshUrl);
 }

--- a/src/o2googledevice.h
+++ b/src/o2googledevice.h
@@ -2,11 +2,11 @@
 #define O2GOOGLEDEVICE_H
 
 #include "o0export.h"
-#include "o2google.h"
+#include "o2.h"
 
 /// "Google Sign-In for TVs and Devices",
 /// A dialect of RFC 8628: OAuth 2.0 Device Authorization Grant
-class O0_EXPORT O2GoogleDevice : public O2Google {
+class O0_EXPORT O2GoogleDevice : public O2 {
     Q_OBJECT
 
 public:


### PR DESCRIPTION
Since O2GoogleDevice now no longer have anything in common with
O2Google, change parent class to O2.