### PR TITLE
fix CMake path when using O2 as subdirectory in a larger CMake project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,9 +267,9 @@ install(FILES ${o2_HDRS}
 )
 
 message(STATUS "Writing pkg-config file...")
-configure_file(${CMAKE_SOURCE_DIR}/o2.pc.cmake ${CMAKE_BINARY_DIR}/o2.pc @ONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/../o2.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/o2.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/o2.pc DESTINATION "${CMAKE_INSTALL_PREFIX}/lib${o2_LIB_SUFFIX}/pkgconfig/")
 
-configure_file(${CMAKE_SOURCE_DIR}/o2-config.h.cmake ${CMAKE_BINARY_DIR}/o2-config.h @ONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/../o2-config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/o2-config.h @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/o2-config.h DESTINATION "${CMAKE_INSTALL_PREFIX}/include/o2")
 


### PR DESCRIPTION
When using O2 as a sub-project of a larger CMake project, the directory `CMAKE_SOURCE_DIR` points to the parent project instead to the O2 directory. `CMAKE_CURRENT_LIST_DIR` points to the directory of the currently processed `CMakeLists.txt` file.

Not sure whether `CMAKE_BINARY_DIR` should also be replaced by `CMAKE_CURRENT_BINARY_DIR`. Probably yes.
