### PR TITLE
fix typo and add note about O0SettingsStore ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ O2 provides simple storage classes for writing OAuth tokens in a peristent locat
     o1->setStore(settings);
     ...
 
-Once set, the O0BaseAuth takes ownership of the Q0SettingsStore object.
+Once set, the O0BaseAuth takes ownership of the O0SettingsStore object.
 
 You can also create it with your customized QSettings object. O2SettingsStore will then use that QSettings object for storing the tokens:
 


### PR DESCRIPTION
Fixed typos in README (object pointers were missing).

I also added a note that the ownership of `O0SettingsStore` is transferred in `setStore()`. I had a multi-hour debugging session because of that...
