### PR TITLE
add finished() signal with error text argument

### DIFF
--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -248,6 +248,7 @@ void O2Requestor::finish() {
     reply_->deleteLater();
     QList<QNetworkReply::RawHeaderPair> headers = reply_->rawHeaderPairs();
     Q_EMIT finished(id_, error_, data);
+    Q_EMIT finished(id_, error_, reply_->errorString(), data);
     Q_EMIT finished(id_, error_, data, headers);
 }
 

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -68,7 +68,10 @@ Q_SIGNALS:
     /// Emitted when a request has been completed or failed.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data);
 
-    /// Emitted when a request has been completed or faled. Also reply headers will be provided.
+    /// Emitted when a request has been completed or failed.
+    void finished(int id, QNetworkReply::NetworkError error, QString errorText, QByteArray data);
+
+    /// Emitted when a request has been completed or failed. Also reply headers will be provided.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data, QList<QNetworkReply::RawHeaderPair> headers);
 
     /// Emitted when an upload has progressed.


### PR DESCRIPTION
Adds an additional `finished()` signal that contains the textual error message. See #142 .