### PR TITLE
Support for HTTP DELETE operation

### DIFF
--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -103,6 +103,19 @@ int O2Requestor::put(const QNetworkRequest & req, QHttpMultiPart* data, int time
     return id_;
 }
 
+int O2Requestor::deleteResource(const QNetworkRequest & req, int timeout/* = 60*1000*/)
+{
+    if (-1 == setup(req, QNetworkAccessManager::DeleteOperation)) {
+        return -1;
+    }
+    rawData_ = false;
+    reply_ = manager_->deleteResource(request_);
+    timedReplies_.add(new O2Reply(reply_, timeout));
+    connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+    connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
+    return id_;
+}
+
 int O2Requestor::customRequest(const QNetworkRequest &req, const QByteArray &verb, const QByteArray &data, int timeout/* = 60*1000*/)
 {
     (void)timeout;

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -55,6 +55,10 @@ public Q_SLOTS:
     int put(const QNetworkRequest &req, const QByteArray &data, int timeout = 60*1000);
     int put(const QNetworkRequest &req, QHttpMultiPart* data, int timeout = 60*1000);
 
+    /// Make a DELETE request.
+    /// @return Request ID or -1 if there are too many requests in the queue.
+    int deleteResource(const QNetworkRequest &req, int timeout = 60*1000);
+
     /// Make a HEAD request.
     /// @return Request ID or -1 if there are too many requests in the queue.
     int head(const QNetworkRequest &req, int timeout = 60*1000);


### PR DESCRIPTION
Added support for HTTP `DELETE` operations in the `O2Requestor`.
Since `delete` is a C++ keyword, I have named the function `deleteResource()` just like the Qt function.
