### PR TITLE
also add an errorText parameter to the finished() signal with headers

### DIFF
--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -263,6 +263,7 @@ void O2Requestor::finish() {
     Q_EMIT finished(id_, error_, data);
     Q_EMIT finished(id_, error_, reply_->errorString(), data);
     Q_EMIT finished(id_, error_, data, headers);
+    Q_EMIT finished(id_, error_, reply_->errorString(), data, headers);
 }
 
 void O2Requestor::retry() {

--- a/src/o2requestor.h
+++ b/src/o2requestor.h
@@ -78,6 +78,9 @@ Q_SIGNALS:
     /// Emitted when a request has been completed or failed. Also reply headers will be provided.
     void finished(int id, QNetworkReply::NetworkError error, QByteArray data, QList<QNetworkReply::RawHeaderPair> headers);
 
+    /// Emitted when a request has been completed or failed. Also reply headers will be provided.
+    void finished(int id, QNetworkReply::NetworkError error, QString errorText, QByteArray data, QList<QNetworkReply::RawHeaderPair> headers);
+
     /// Emitted when an upload has progressed.
     void uploadProgress(int id, qint64 bytesSent, qint64 bytesTotal);
 


### PR DESCRIPTION
Same as #143 for the `finished()` signal that includes the reply headers.