### PR TITLE
Qt6 compatibility 

### DIFF
--- a/o2.pro
+++ b/o2.pro
@@ -21,7 +21,12 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-mac: QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
+greaterThan(QT_VERSION, 6.2) {
+    macx: {
+        message("Building universal library on macOS")
+	QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+    }
+}
 
 PREFIX=$$PREFIX
 SRC_PREFIX=$$SRC_PREFIX

--- a/src/o0requestparameter.h
+++ b/src/o0requestparameter.h
@@ -3,6 +3,8 @@
 
 #include "o0export.h"
 
+#include <QByteArray>
+
 /// Request parameter (name-value pair) participating in authentication.
 struct O0_EXPORT O0RequestParameter {
     O0RequestParameter(const QByteArray &n, const QByteArray &v): name(n), value(v) {}

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -266,7 +266,11 @@ void O1::link() {
     headers.append(O0RequestParameter(O2_OAUTH_CALLBACK, callbackUrl().arg(localPort()).toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
+#if QT_VERSION >= 0x050800
+    headers.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentSecsSinceEpoch()).toLatin1()));
+#else
     headers.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     headers.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
     headers.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, signatureMethod().toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_SIGNATURE, generateSignature(headers, request, requestParameters(), QNetworkAccessManager::PostOperation)));
@@ -350,7 +354,11 @@ void O1::exchangeToken() {
     QList<O0RequestParameter> oauthParams;
     oauthParams.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
+#if QT_VERSION >= 0x050800
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, requestToken_.toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERFIER, verifier_.toLatin1()));
@@ -415,7 +423,11 @@ QMap<QString, QString> O1::parseResponse(const QByteArray &response) {
 }
 
 QByteArray O1::nonce() {
-    QString u = QString::number(QDateTime::currentDateTimeUtc().toTime_t());
+#if QT_VERSION >= 0x050800
+    QString u = QString::number(QDateTime::currentSecsSinceEpoch()).toLatin1();
+#else
+    QString u = QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1();
+#endif
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     u.append(QString::number(QRandomGenerator::global()->generate()));
 #else

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -283,7 +283,11 @@ void O1::link() {
     decorateRequest(request, headers);
     request.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
     QNetworkReply *reply = manager_->post(request, QByteArray());
+#if QT_VERSION < 0x051500
     connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenRequestError(QNetworkReply::NetworkError)));
+#else
+    connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenRequestError(QNetworkReply::NetworkError)));
+#endif
     connect(reply, SIGNAL(finished()), this, SLOT(onTokenRequestFinished()));
 }
 
@@ -369,7 +373,11 @@ void O1::exchangeToken() {
     decorateRequest(request, oauthParams);
     request.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
     QNetworkReply *reply = manager_->post(request, QByteArray());
+#if QT_VERSION < 0x051500
     connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenExchangeError(QNetworkReply::NetworkError)));
+#else
+    connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenExchangeError(QNetworkReply::NetworkError)));
+#endif
     connect(reply, SIGNAL(finished()), this, SLOT(onTokenExchangeFinished()));
 }
 

--- a/src/o1.h
+++ b/src/o1.h
@@ -32,7 +32,7 @@ public:
     void setRequestTokenUrl(const QUrl &value);
 
     /// Parameters to pass with request URL.
-    Q_PROPERTY(QList<O0RequestParameter> requestParameters READ requestParameters WRITE setRequestParameters);
+    Q_PROPERTY(QList<O0RequestParameter> requestParameters READ requestParameters WRITE setRequestParameters)
     QList<O0RequestParameter> requestParameters();
     void setRequestParameters(const QList<O0RequestParameter> &value);
 

--- a/src/o1requestor.cpp
+++ b/src/o1requestor.cpp
@@ -45,7 +45,11 @@ QNetworkRequest O1Requestor::setup(const QNetworkRequest &req, const QList<O0Req
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, authenticator_->token().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, authenticator_->signatureMethod().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, O1::nonce()));
+#if QT_VERSION >= 0x050800
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
 
     // Add signature parameter
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE, authenticator_->generateSignature(oauthParams, req, signingParameters, operation)));

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -16,6 +16,12 @@
 #include <QUrlQuery>
 #endif
 
+#if QT_VERSION >= 0x050000
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
 #include "o2.h"
 #include "o2pollserver.h"
 #include "o2replyserver.h"
@@ -187,7 +193,11 @@ void O2::link() {
 
     if (grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowImplicit) {
 
+#if QT_VERSION >= 0x050000
+        QString uniqueState = QUuid::createUuid().toString().remove(QRegularExpression("([^a-zA-Z0-9]|[-])"));
+#else
         QString uniqueState = QUuid::createUuid().toString().remove(QRegExp("([^a-zA-Z0-9]|[-])"));
+#endif
         if (useExternalWebInterceptor_) {
             // Save redirect URI, as we have to reuse it when requesting the access token
             redirectUri_ = localhostPolicy_.arg(localPort());

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -259,7 +259,11 @@ void O2::link() {
         QNetworkReply *tokenReply = manager_->post(tokenRequest, payload);
 
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+        connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     }
     else if (grantFlow_ == GrantFlowDevice) {
         QList<O0RequestParameter> parameters;
@@ -273,7 +277,11 @@ void O2::link() {
         QNetworkReply *tokenReply = manager_->post(deviceRequest, payload);
 
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onDeviceAuthReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+        connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     }
 }
 
@@ -321,7 +329,11 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         QNetworkReply *tokenReply = manager_->post(tokenRequest, data);
         timedReplies_.add(tokenReply);
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+        connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     } else if (grantFlow_ == GrantFlowImplicit || grantFlow_ == GrantFlowDevice) {
       // Check for mandatory tokens
       if (response.contains(O2_OAUTH2_ACCESS_TOKEN)) {
@@ -525,7 +537,11 @@ void O2::refresh() {
     QNetworkReply *refreshReply = manager_->post(refreshRequest, data);
     timedReplies_.add(refreshReply);
     connect(refreshReply, SIGNAL(finished()), this, SLOT(onRefreshFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
     connect(refreshReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRefreshError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(refreshReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRefreshError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
 }
 
 void O2::onRefreshFinished() {

--- a/src/o2.h
+++ b/src/o2.h
@@ -87,7 +87,7 @@ public:
     void setRefreshTokenUrl(const QString &value);
 
     /// Grant type (if non-standard)
-    Q_PROPERTY(QString grantType READ grantType WRITE setGrantType);
+    Q_PROPERTY(QString grantType READ grantType WRITE setGrantType)
     QString grantType();
     void setGrantType(const QString &value);
 

--- a/src/o2facebook.cpp
+++ b/src/o2facebook.cpp
@@ -60,7 +60,11 @@ void O2Facebook::onVerificationReceived(const QMap<QString, QString> response) {
     QNetworkReply *tokenReply = manager_->get(tokenRequest);
     timedReplies_.add(tokenReply);
     connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
     connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
 }
 
 void O2Facebook::onTokenReplyFinished() {

--- a/src/o2reply.cpp
+++ b/src/o2reply.cpp
@@ -5,7 +5,11 @@
 
 O2Reply::O2Reply(QNetworkReply *r, int timeOut, QObject *parent): QTimer(parent), reply(r) {
     setSingleShot(true);
+#if QT_VERSION < 0x051500
     connect(this, SIGNAL(error(QNetworkReply::NetworkError)), reply, SIGNAL(error(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(this, SIGNAL(error(QNetworkReply::NetworkError)), reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(this, SIGNAL(timeout()), this, SLOT(onTimeOut()), Qt::QueuedConnection);
     start(timeOut);
 }

--- a/src/o2requestor.cpp
+++ b/src/o2requestor.cpp
@@ -38,7 +38,12 @@ int O2Requestor::get(const QNetworkRequest &req, int timeout/* = 60*1000*/) {
     }
     reply_ = manager_->get(request_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     return id_;
 }
@@ -51,7 +56,11 @@ int O2Requestor::post(const QNetworkRequest &req, const QByteArray &data, int ti
     data_ = data;
     reply_ = manager_->post(request_, data_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
     return id_;
@@ -67,7 +76,11 @@ int O2Requestor::post(const QNetworkRequest & req, QHttpMultiPart* data, int tim
     reply_ = manager_->post(request_, multipartData_);
     multipartData_->setParent(reply_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
     return id_;
@@ -81,7 +94,11 @@ int O2Requestor::put(const QNetworkRequest &req, const QByteArray &data, int tim
     data_ = data;
     reply_ = manager_->put(request_, data_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
     return id_;
@@ -97,7 +114,11 @@ int O2Requestor::put(const QNetworkRequest & req, QHttpMultiPart* data, int time
     reply_ = manager_->put(request_, multipartData_);
     multipartData_->setParent(reply_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
     return id_;
@@ -111,7 +132,11 @@ int O2Requestor::deleteResource(const QNetworkRequest & req, int timeout/* = 60*
     rawData_ = false;
     reply_ = manager_->deleteResource(request_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     return id_;
 }
@@ -129,7 +154,11 @@ int O2Requestor::customRequest(const QNetworkRequest &req, const QByteArray &ver
     reply_ = manager_->sendCustomRequest(request_, verb, buffer);
     buffer->setParent(reply_);
     timedReplies_.add(new O2Reply(reply_));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
     return id_;
@@ -142,7 +171,11 @@ int O2Requestor::head(const QNetworkRequest &req, int timeout/* = 60*1000*/)
     }
     reply_ = manager_->head(request_);
     timedReplies_.add(new O2Reply(reply_, timeout));
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     return id_;
 }
@@ -320,7 +353,11 @@ void O2Requestor::retry() {
         break;
     }
     timedReplies_.add(reply_);
+#if QT_VERSION < 0x051500
     connect(reply_, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+    connect(reply_, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onRequestError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     connect(reply_, SIGNAL(finished()), this, SLOT(onRequestFinished()), Qt::QueuedConnection);
     connect(reply_, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(onUploadProgress(qint64,qint64)));
 }

--- a/src/o2simplecrypt.cpp
+++ b/src/o2simplecrypt.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QIODevice>
 
 O0SimpleCrypt::O0SimpleCrypt():
     m_key(0),

--- a/src/o2simplecrypt.cpp
+++ b/src/o2simplecrypt.cpp
@@ -112,7 +112,11 @@ QByteArray O0SimpleCrypt::encryptToByteArray(QByteArray plaintext)
     if (m_protectionMode == ProtectionChecksum) {
         flags |= CryptoFlagChecksum;
         QDataStream s(&integrityProtection, QIODevice::WriteOnly);
+#if QT_VERSION >= 0x060000
+        s << qChecksum(QByteArrayView(ba));
+#else
         s << qChecksum(ba.constData(), ba.length());
+#endif
     } else if (m_protectionMode == ProtectionHash) {
         flags |= CryptoFlagHash;
         QCryptographicHash hash(QCryptographicHash::Sha1);
@@ -240,7 +244,11 @@ QByteArray O0SimpleCrypt::decryptToByteArray(QByteArray cypher)
             s >> storedChecksum;
         }
         ba = ba.mid(2);
+#if QT_VERSION >= 0x060000
+        quint16 checksum = qChecksum(QByteArrayView(ba));
+#else
         quint16 checksum = qChecksum(ba.constData(), ba.length());
+#endif
         integrityOk = (checksum == storedChecksum);
     } else if (flags.testFlag(CryptoFlagHash)) {
         if (ba.length() < 20) {

--- a/src/o2skydrive.cpp
+++ b/src/o2skydrive.cpp
@@ -85,7 +85,11 @@ void O2Skydrive::redirected(const QUrl &url) {
         QNetworkReply *tokenReply = manager_->post(tokenRequest, data);
         timedReplies_.add(tokenReply);
         connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
         connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#else
+        connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
     } else {
         // Get access token
         QString urlToken = "";

--- a/src/o2uber.cpp
+++ b/src/o2uber.cpp
@@ -66,8 +66,11 @@ void O2Uber::onVerificationReceived(const QMap<QString, QString> response){
     QNetworkReply *tokenReply = manager_->post(tokenRequest, QByteArray());
     timedReplies_.add(tokenReply);
     connect(tokenReply, SIGNAL(finished()), this, SLOT(onTokenReplyFinished()), Qt::QueuedConnection);
+#if QT_VERSION < 0x051500
     connect(tokenReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
-
+#else
+    connect(tokenReply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenReplyError(QNetworkReply::NetworkError)), Qt::QueuedConnection);
+#endif
 }
 
 void O2Uber::onTokenReplyFinished(){

--- a/src/oxtwitter.cpp
+++ b/src/oxtwitter.cpp
@@ -68,6 +68,10 @@ void OXTwitter::link() {
     decorateRequest(request, oauthParams);
     request.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
     QNetworkReply *reply = manager_->post(request, createQueryParameters(xAuthParams_));
+#if QT_VERSION < 0x051500
     connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(onTokenExchangeError(QNetworkReply::NetworkError)));
+#else
+    connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this, SLOT(onTokenExchangeError(QNetworkReply::NetworkError)));
+#endif
     connect(reply, SIGNAL(finished()), this, SLOT(onTokenExchangeFinished()));
 }

--- a/src/oxtwitter.cpp
+++ b/src/oxtwitter.cpp
@@ -51,7 +51,11 @@ void OXTwitter::link() {
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, O2_SIGNATURE_TYPE_HMAC_SHA1));
     oauthParams.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
+#if QT_VERSION >= 0x050800
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, QByteArray("")));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERFIER, QByteArray("")));


### PR DESCRIPTION
Replaces all obsoleted Qt 5 methods and classes with new Qt 6 counterparts:
- QRegExp -> QRegularExpression ( >= Qt 5 )
- QNetworkReply::error -> QNetworkReply::errorOccurred ( >= Qt 5.15 )
- QDateTime::toTime_t -> QDateTime::currentSecsSinceEpoch ( >= Qt 5.8; only a replacement for the specific usage)
- qChecksum(char*, int len) ->  qChecksum(QByteArrayView) ( >= Qt 6)

The library can now also be built as a universal library on macOS to natively support Apple Silicon. Needs at least Qt 6.2.