### PR TITLE
Make O2 Compile with QT6 

### DIFF
--- a/o2.pro
+++ b/o2.pro
@@ -3,6 +3,13 @@ mac: PREFIX=/Users/hans/devel/libraries/osx
 win32: PREFIX=c:/devel/libraries/win64
 linux: PREFIX=/home/hans/devel/libraries/linux64
 
+# QT6 Support
+equals(QT_MAJOR_VERSION, 6) {
+win32: TARGET = o2_qt6
+mac: TARGET = o2_qt6
+}
+
+# O2 stuff
 QT -= gui
 
 TEMPLATE = lib

--- a/src/o0export.h
+++ b/src/o0export.h
@@ -14,4 +14,10 @@
     #define O0_EXPORT
 #endif
 
+#ifndef O0_QT6
+#  if QT_VERSION >= 0x060000
+#    define O0_QT6
+#  endif
+#endif
+
 #endif // O0_EXPORT

--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -266,7 +266,11 @@ void O1::link() {
     headers.append(O0RequestParameter(O2_OAUTH_CALLBACK, callbackUrl().arg(localPort()).toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
+#ifdef O0_QT6
+    headers.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()).toLatin1()));
+#else
     headers.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     headers.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
     headers.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, signatureMethod().toLatin1()));
     headers.append(O0RequestParameter(O2_OAUTH_SIGNATURE, generateSignature(headers, request, requestParameters(), QNetworkAccessManager::PostOperation)));
@@ -350,7 +354,11 @@ void O1::exchangeToken() {
     QList<O0RequestParameter> oauthParams;
     oauthParams.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
+#ifdef O0_QT6
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, requestToken_.toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERFIER, verifier_.toLatin1()));
@@ -415,7 +423,11 @@ QMap<QString, QString> O1::parseResponse(const QByteArray &response) {
 }
 
 QByteArray O1::nonce() {
+#ifdef O0_QT6
+    QString u = QString::number(QDateTime::currentDateTimeUtc().toSecsSinceEpoch());
+#else
     QString u = QString::number(QDateTime::currentDateTimeUtc().toTime_t());
+#endif
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     u.append(QString::number(QRandomGenerator::global()->generate()));
 #else

--- a/src/o1requestor.cpp
+++ b/src/o1requestor.cpp
@@ -45,7 +45,11 @@ QNetworkRequest O1Requestor::setup(const QNetworkRequest &req, const QList<O0Req
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, authenticator_->token().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, authenticator_->signatureMethod().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, O1::nonce()));
+#ifdef O0_QT6
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
 
     // Add signature parameter
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE, authenticator_->generateSignature(oauthParams, req, signingParameters, operation)));

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -23,6 +23,10 @@
 #include "o0jsonresponse.h"
 #include "o0settingsstore.h"
 
+#ifdef O0_QT6
+#include <QRegularExpression>
+#endif
+
 /// Add query parameters to a query
 static void addQueryParametersToUrl(QUrl &url,  QList<QPair<QString, QString> > parameters) {
 #if QT_VERSION < 0x050000
@@ -187,7 +191,11 @@ void O2::link() {
 
     if (grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowImplicit) {
 
+#ifdef O0_QT6
+        QString uniqueState = QUuid::createUuid().toString().remove(QRegularExpression("([^a-zA-Z0-9]|[-])"));
+#else
         QString uniqueState = QUuid::createUuid().toString().remove(QRegExp("([^a-zA-Z0-9]|[-])"));
+#endif
         if (useExternalWebInterceptor_) {
             // Save redirect URI, as we have to reuse it when requesting the access token
             redirectUri_ = localhostPolicy_.arg(localPort());

--- a/src/o2google.h
+++ b/src/o2google.h
@@ -7,7 +7,7 @@
 
 #include "o2.h"
 
-class O2Google : public O2 {
+class O0_EXPORT O2Google : public O2 {
     Q_OBJECT
 public:
     explicit O2Google(QObject *parent = 0);

--- a/src/oxtwitter.cpp
+++ b/src/oxtwitter.cpp
@@ -51,7 +51,11 @@ void OXTwitter::link() {
     oauthParams.append(O0RequestParameter(O2_OAUTH_SIGNATURE_METHOD, O2_SIGNATURE_TYPE_HMAC_SHA1));
     oauthParams.append(O0RequestParameter(O2_OAUTH_CONSUMER_KEY, clientId().toLatin1()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERSION, "1.0"));
+#ifdef O0_QT6
+    oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()).toLatin1()));
+#else
     oauthParams.append(O0RequestParameter(O2_OAUTH_TIMESTAMP, QString::number(QDateTime::currentDateTimeUtc().toTime_t()).toLatin1()));
+#endif
     oauthParams.append(O0RequestParameter(O2_OAUTH_NONCE, nonce()));
     oauthParams.append(O0RequestParameter(O2_OAUTH_TOKEN, QByteArray("")));
     oauthParams.append(O0RequestParameter(O2_OAUTH_VERFIER, QByteArray("")));


### PR DESCRIPTION
Made O2 compile with QT6. 
QT6 changed some things and removed some functions. 

Correct o2google.h to include O0Export, otherwise we can't link to it when using a DLL.