### PR TITLE
Support Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(API_VERSION ${VER_MAJOR}.${VER_MINOR}.${API_VER_PATCH})
 
 project(o2)
 
+option(o2_WITH_QT6 "Use Qt6" OFF)
 option(o2_WITH_QT5 "Use Qt5" ON)
 
 set(o2_LIB_SUFFIX "" CACHE STRING "Suffix for install 'lib' directory, e.g. 64 for lib64")

--- a/cmake/modules/FindQt6Keychain.cmake
+++ b/cmake/modules/FindQt6Keychain.cmake
@@ -1,0 +1,38 @@
+# (c) 2014 Copyright ownCloud GmbH
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING* file.
+
+# - Try to find QtKeychain
+# Once done this will define
+#  QTKEYCHAIN_FOUND - System has QtKeychain
+#  QTKEYCHAIN_INCLUDE_DIRS - The QtKeychain include directories
+#  QTKEYCHAIN_LIBRARIES - The libraries needed to use QtKeychain
+#  QTKEYCHAIN_DEFINITIONS - Compiler switches required for using LibXml2
+
+find_path(QTKEYCHAIN_INCLUDE_DIR
+        NAMES
+        keychain.h
+        PATH_SUFFIXES
+        qt6keychain
+        )
+
+find_library(QTKEYCHAIN_LIBRARY
+        NAMES
+        qt6keychain
+        lib6qtkeychain
+        PATHS
+        /usr/lib
+        /usr/lib/${CMAKE_ARCH_TRIPLET}
+        /usr/local/lib
+        /opt/local/lib
+        ${CMAKE_LIBRARY_PATH}
+        ${CMAKE_INSTALL_PREFIX}/lib
+        )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set QTKEYCHAIN_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Qt6Keychain  DEFAULT_MSG
+        QTKEYCHAIN_LIBRARY QTKEYCHAIN_INCLUDE_DIR)
+
+mark_as_advanced(QTKEYCHAIN_INCLUDE_DIR QTKEYCHAIN_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,19 +4,18 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if(o2_WITH_QT5)
+if(o2_WITH_QT6)
+    find_package(Qt6 COMPONENTS Core Network REQUIRED)
+elseif(o2_WITH_QT5)
     find_package(Qt5 COMPONENTS Core Network REQUIRED)
-else(o2_WITH_QT5)
+else()
     set(QT_USE_QTNETWORK true)
     set(QT_USE_QTSCRIPT true)
     find_package(Qt4 REQUIRED)
-endif(o2_WITH_QT5)
-#find_package(QJson REQUIRED)
-
-if (NOT o2_WITH_QT5)
     include( ${QT_USE_FILE} )
-endif(NOT o2_WITH_QT5)
-
+    add_definitions(${QT4_DEFINITIONS})
+endif()
+#find_package(QJson REQUIRED)
 
 set( o2_SRCS
     o2.cpp
@@ -192,7 +191,9 @@ if(o2_WITH_MSGRAPH)
 endif(o2_WITH_MSGRAPH)
 
 if(o2_WITH_KEYCHAIN)
-    if (Qt5Core_DIR)
+    if(Qt6Core_DIR)
+        find_package(Qt6Keychain REQUIRED)
+    elseif(Qt5Core_DIR)
         find_package(Qt5Keychain REQUIRED)
     else()
         find_package(QtKeychain REQUIRED)
@@ -219,10 +220,6 @@ endif(o2_WITH_KEYCHAIN)
 
 
 
-if(NOT o2_WITH_QT5)
-    add_definitions(${QT4_DEFINITIONS})
-endif(NOT o2_WITH_QT5)
-
 if(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042) # in CMake >= 2.8.12
     cmake_policy(SET CMP0042 OLD)
     set(CMAKE_MACOSX_RPATH OFF) # don't embed @rpath in install name
@@ -234,11 +231,13 @@ if(BUILD_SHARED_LIBS)
     add_definitions( -DO2_SHARED_LIB )
 endif(BUILD_SHARED_LIBS)
 
-if(o2_WITH_QT5)
+if(o2_WITH_QT6)
+    target_link_libraries( o2 Qt6::Core Qt6::Network ${LINK_TARGETS})
+elseif(o2_WITH_QT5)
     target_link_libraries( o2 Qt5::Core Qt5::Network ${LINK_TARGETS})
-else(o2_WITH_QT5)
+else()
     target_link_libraries( o2 ${QT_LIBRARIES} ${LINK_TARGETS})
-endif(o2_WITH_QT5)
+endif()
 
 if(BUILD_SHARED_LIBS)
     if(APPLE)

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -8,6 +8,7 @@
 #include <QNetworkAccessManager>
 #include <QDateTime>
 #include <QCryptographicHash>
+#include <QRegularExpression>
 #include <QTimer>
 #include <QVariantMap>
 #include <QUuid>
@@ -187,7 +188,7 @@ void O2::link() {
 
     if (grantFlow_ == GrantFlowAuthorizationCode || grantFlow_ == GrantFlowImplicit) {
 
-        QString uniqueState = QUuid::createUuid().toString().remove(QRegExp("([^a-zA-Z0-9]|[-])"));
+        QString uniqueState = QUuid::createUuid().toString().remove(QRegularExpression("([^a-zA-Z0-9]|[-])"));
         if (useExternalWebInterceptor_) {
             // Save redirect URI, as we have to reuse it when requesting the access token
             redirectUri_ = localhostPolicy_.arg(localPort());

--- a/src/o2simplecrypt.cpp
+++ b/src/o2simplecrypt.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QIODevice>
 
 O0SimpleCrypt::O0SimpleCrypt():
     m_key(0),


### PR DESCRIPTION
A new cmake option `o2_WITH_QT6` is added and default to be OFF.