### PR TITLE
Create CMake package configuration files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,3 +104,26 @@ add_subdirectory(src)
 if(o2_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif(o2_BUILD_EXAMPLES)
+
+install(EXPORT o2
+  FILE o2.cmake
+  DESTINATION lib/cmake/o2
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/o2Config.cmake"
+  INSTALL_DESTINATION "lib/cmake/o2"
+  NO_SET_AND_CHECK_MACRO
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/o2ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/o2Config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/o2ConfigVersion.cmake"
+  DESTINATION lib/cmake/o2
+)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/o2.cmake")
+
+check_required_components(o2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,13 @@ if(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042) # in CMake >= 2.8.12
 endif(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042)
 
 add_library( o2 ${o2_SRCS} ${o2_HDRS} )
+set_target_properties(o2 PROPERTIES PUBLIC_HEADER "${o2_HDRS}")
+
+target_include_directories(o2
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 
 if(BUILD_SHARED_LIBS)
     add_definitions( -DO2_SHARED_LIB )
@@ -257,13 +264,11 @@ else(BUILD_SHARED_LIBS)
 endif(BUILD_SHARED_LIBS)
 
 install(TARGETS o2
+    EXPORT o2
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib${o2_LIB_SUFFIX}
     ARCHIVE DESTINATION lib${o2_LIB_SUFFIX}
-)
-
-install(FILES ${o2_HDRS}
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/o2
+    PUBLIC_HEADER DESTINATION include/o2
 )
 
 message(STATUS "Writing pkg-config file...")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,6 +239,7 @@ target_include_directories(o2
 
 if(BUILD_SHARED_LIBS)
     add_definitions( -DO2_SHARED_LIB )
+    target_compile_definitions(o2 INTERFACE O2_SHARED_LIB)
 endif(BUILD_SHARED_LIBS)
 
 if(o2_WITH_QT5)


### PR DESCRIPTION
This will generate a CMake native package configuration files which can be used to integrate a prebuild version of the O2 library to a CMake-based project with a simple find_package call